### PR TITLE
QA improvements for dev-util/cargo ebuild

### DIFF
--- a/dev-util/cargo/cargo-0.4.0-r1.ebuild
+++ b/dev-util/cargo/cargo-0.4.0-r1.ebuild
@@ -124,8 +124,6 @@ src_prepare() {
 	sed -i \
 		-e "s:/share/doc/cargo:/share/doc/${PF}:" \
 		Makefile.in || die
-
-#	exit
 }
 
 src_configure() {

--- a/dev-util/cargo/cargo-0.4.0-r1.ebuild
+++ b/dev-util/cargo/cargo-0.4.0-r1.ebuild
@@ -80,7 +80,7 @@ LICENSE="|| ( MIT Apache-2.0 )"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-IUSE="doc"
+IUSE="doc test"
 
 COMMON_DEPEND="sys-libs/zlib
 	dev-libs/openssl:*
@@ -94,6 +94,7 @@ DEPEND="${COMMON_DEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${P}-local-deps.patch
+	"${FILESDIR}"/${P}-test.patch
 )
 
 src_unpack() {
@@ -123,23 +124,35 @@ src_prepare() {
 	sed -i \
 		-e "s:/share/doc/cargo:/share/doc/${PF}:" \
 		Makefile.in || die
+
+#	exit
 }
 
 src_configure() {
+	# Defines the level of verbosity.
+	ECARGO_VERBOSE=""
+	[[ -z ${PORTAGE_VERBOSE} ]] || ECARGO_VERBOSE=1
+
 	# Cargo only supports these GNU triples:
 	# - Linux: <arch>-unknown-linux-gnu
 	# - MacOS: <arch>-apple-darwin
 	# - Windows: <arch>-pc-windows-gnu
 	# where <arch> could be 'x86_64' (amd64) or 'i686' (x86)
-	local CTARGET="-unknown-linux-gnu"
+	CTARGET="-unknown-linux-gnu"
 	use amd64 && CTARGET="x86_64${CTARGET}"
 	use x86 && CTARGET="i686${CTARGET}"
 
+	# NOTE: 'disable-nightly' is used by crates (such as 'matches') to entirely
+	# skip their internal libraries that make use of unstable rustc features.
+	# Don't use 'enable-nightly' with a stable release of rustc as DEPEND,
+	# otherwise you could get compilation issues.
+	# see: github.com/gentoo/gentoo-rust/issues/13
 	local myeconfargs=(
 		--build=${CTARGET}
 		--host=${CTARGET}
 		--target=${CTARGET}
 		--enable-optimize
+		--disable-nightly
 		--disable-verify-install
 		--disable-debug
 		--disable-cross-tests
@@ -150,18 +163,34 @@ src_configure() {
 
 src_compile() {
 	# Building sources
-	autotools-utils_src_compile VERBOSE=1 PKG_CONFIG_PATH=""
+	autotools-utils_src_compile VERBOSE=${ECARGO_VERBOSE} PKG_CONFIG_PATH=""
 
 	# Building HTML documentation
 	use doc && emake doc
 }
 
 src_install() {
-	autotools-utils_src_install VERBOSE=1 CFG_DISABLE_LDCONFIG="true"
+	autotools-utils_src_install VERBOSE=${ECARGO_VERBOSE} CFG_DISABLE_LDCONFIG="true"
 
 	# Install HTML documentation
 	use doc && dohtml -r target/doc/*
 
 	dobashcomp "${ED}"/usr/etc/bash_completion.d/cargo
 	rm -r "${ED}"/usr/etc || die
+}
+
+src_test() {
+	if has sandbox $FEATURES && has network-sandbox $FEATURES; then
+		eerror "Some tests require sandbox, and network-sandbox to be disabled in FEATURES."
+	fi
+
+	# Running unit tests
+	# NOTE: by default 'make test' uses the copy of cargo (v0.0.1-pre-nighyly)
+	# from the installer snapshot instead of the version just built, so the
+	# ebuild needs to override the value of CFG_LOCAL_CARGO to avoid false
+	# positives from unit tests.
+	autotools-utils_src_test \
+		CFG_ENABLE_OPTIMIZE=1 \
+		VERBOSE=${ECARGO_VERBOSE} \
+		CFG_LOCAL_CARGO="${WORKDIR}"/${P}/target/${CTARGET}/release/cargo
 }

--- a/dev-util/cargo/files/cargo-0.4.0-test.patch
+++ b/dev-util/cargo/files/cargo-0.4.0-test.patch
@@ -1,0 +1,93 @@
+--- hamcrest-0.1.0/Cargo.toml
++++ hamcrest-0.1.0/Cargo.toml
+@@ -5,4 +5,4 @@
+ authors = ["Carllerche <me@carllerche.com>"]
+ 
+ [dependencies]
+-num = "0.1.25"
++num = { version = "0.1.25", path = "../num-0.1.25" }
+--- rand-0.3.8/Cargo.toml
++++ rand-0.3.8/Cargo.toml
+@@ -14,11 +14,7 @@
+ keywords = ["random"]
+ 
+ [dependencies]
+-libc = "0.1.1"
+-
+-[dev-dependencies.rand_macros]
+-path = "rand_macros"
+-version = "*"
++libc = { version = "0.1.8", path = "../libc-0.1.8" }
+ 
+ [dev-dependencies]
+-log = "0.3.0"
++log = { version = "0.3.1", path = "../log-0.3.1" }
+--- tempdir-0.3.4/Cargo.toml
++++ tempdir-0.3.4/Cargo.toml
+@@ -14,4 +14,4 @@
+ """
+ 
+ [dependencies]
+-rand = "0.3"
++rand = { version = "0.3.8", path = "../rand-0.3.8" }
+--- num-0.1.25/Cargo.toml
++++ num-0.1.25/Cargo.toml
+@@ -14,8 +14,8 @@
+ """
+ 
+ [dependencies]
+-rustc-serialize = { version = "0.3.13", optional = true }
+-rand = { version = "0.3.8", optional = true }
++rustc-serialize = { version = "0.3.14", optional = true, path = "../rustc-serialize-0.3.14" }
++rand = { version = "0.3.8", optional = true, path = "../rand-0.3.8" }
+ 
+ [features]
+ 
+--- toml-0.1.21/Cargo.toml
++++ toml-0.1.21/Cargo.toml
+@@ -16,7 +16,7 @@
+ """
+ 
+ [dependencies]
+-rustc-serialize = { optional = true, version = "0.3.0", path = "../rustc-serialize-0.3.14" }
++rustc-serialize = { optional = true, version = "0.3.14", path = "../rustc-serialize-0.3.14" }
+ 
+ [features]
+ default = ["rustc-serialize"]
+--- cargo-0.4.0/Cargo.toml
++++ cargo-0.4.0/Cargo.toml
+@@ -40,6 +40,12 @@
+ toml = { version = "0.1.21", path = "../toml-0.1.21" }
+ url = { version = "0.2.35", path = "../url-0.2.35" }
+ 
++[dev-dependencies]
++hamcrest = { version = "0.1.0", path = "../hamcrest-0.1.0" }
++bufstream = { version = "0.1.1", path = "../bufstream-0.1.1" }
++tempdir = { version = "0.3.4", path = "../tempdir-0.3.4" }
++filetime = { version = "0.1.5", path = "../filetime-0.1.5" } 
++
+ [[bin]]
+ name = "cargo"
+ test = false
+--- cargo-0.4.0/Makefile.in
++++ cargo-0.4.0/Makefile.in
+@@ -88,7 +88,9 @@
+ 
+ test-unit-$(1): $$(CARGO)
+ 	@mkdir -p target/$(1)/cit
+-	$$(CARGO) test --target $(1) $$(VERBOSE_FLAG) $$(only)
++	"$$(CFG_RUSTC)" -V
++	"$$(CARGO)" --version
++	$$(CARGO) test --target $(1) $$(OPT_FLAG) $$(VERBOSE_FLAG) $$(only)
+ endef
+ $(foreach target,$(CFG_TARGET),$(eval $(call CARGO_TARGET,$(target))))
+ 
+@@ -99,7 +101,7 @@
+ 
+ # === Tests
+ 
+-test: style no-exes $(foreach target,$(CFG_TARGET),test-unit-$(target))
++test: style $(foreach target,$(CFG_TARGET),test-unit-$(target))
+ 
+ style:
+ 	sh tests/check-style.sh


### PR DESCRIPTION
[dev-util/cargo] Add support for USE 'test' and fix compilation issues with rustc-1.2.0.

 - Added missing src_test() phase;
 - Fixes #13 (by default 'enable-nightly' is set and should be disabled when used together with a stable releases of rustc);
 - Ebuild now correctly honours $PORTAGE_VERBOSE;