### PR TITLE
[dev-util/cargo] Fix conflicting packages.

### DIFF
--- a/dev-util/cargo-bin/cargo-bin-99.ebuild
+++ b/dev-util/cargo-bin/cargo-bin-99.ebuild
@@ -14,7 +14,7 @@ LICENSE="|| ( MIT Apache-2.0 )"
 SLOT="0"
 KEYWORDS=""
 
-RDEPEND="
+RDEPEND="!dev-util/cargo
 	dev-libs/openssl:*
 	net-misc/curl[ssl]
 	net-libs/libssh2

--- a/dev-util/cargo-bin/cargo-bin-999.ebuild
+++ b/dev-util/cargo-bin/cargo-bin-999.ebuild
@@ -14,7 +14,7 @@ LICENSE="|| ( MIT Apache-2.0 )"
 SLOT="0"
 KEYWORDS=""
 
-RDEPEND="
+RDEPEND="!dev-util/cargo
 	dev-libs/openssl:*
 	net-misc/curl[ssl]
 	net-libs/libssh2

--- a/dev-util/cargo/cargo-0.2.0.ebuild
+++ b/dev-util/cargo/cargo-0.2.0.ebuild
@@ -78,6 +78,7 @@ COMMON_DEPEND="sys-libs/zlib
 	net-libs/libssh2
 	net-libs/http-parser"
 RDEPEND="${COMMON_DEPEND}
+	!dev-util/cargo-bin
 	net-misc/curl[ssl]"
 DEPEND="${COMMON_DEPEND}
 	dev-util/cmake"

--- a/dev-util/cargo/cargo-0.3.0.ebuild
+++ b/dev-util/cargo/cargo-0.3.0.ebuild
@@ -75,6 +75,7 @@ COMMON_DEPEND="sys-libs/zlib
 	net-libs/libssh2
 	net-libs/http-parser"
 RDEPEND="${COMMON_DEPEND}
+	!dev-util/cargo-bin
 	net-misc/curl[ssl]"
 DEPEND="${COMMON_DEPEND}
 	|| ( >=dev-lang/rust-1.1.0 >=dev-lang/rust-bin-1.1.0 )

--- a/dev-util/cargo/cargo-0.4.0-r2.ebuild
+++ b/dev-util/cargo/cargo-0.4.0-r2.ebuild
@@ -87,6 +87,7 @@ COMMON_DEPEND="sys-libs/zlib
 	net-libs/libssh2
 	net-libs/http-parser"
 RDEPEND="${COMMON_DEPEND}
+	!dev-util/cargo-bin
 	net-misc/curl[ssl]"
 DEPEND="${COMMON_DEPEND}
 	|| ( >=dev-lang/rust-1.1.0 >=dev-lang/rust-bin-1.1.0 )


### PR DESCRIPTION
Both `dev-util/cargo` and `dev-util/cargo-bin` install binary `/usr/bin/cargo`
triggering emerge file collision detection. For this reason both the ebuilds
should not be installed at the same time on the same system; this PR adds blocks
to all cargo ebuilds.