### PR TITLE
dev-lang/rust-bin: also include stdlib in nightly Rust install

### DIFF
--- a/dev-lang/rust-bin/rust-bin-999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-999.ebuild
@@ -37,7 +37,8 @@ src_unpack() {
 }
 
 src_install() {
-	local components=rustc
+	local std=$(./install.sh --list-components | grep 'std' | sed -e 's/^\* //')
+	local components="rustc,${std}"
 	use doc && components="${components},rust-docs"
 	./install.sh \
 		--components="${components}" \


### PR DESCRIPTION
Without it nightly Rust is quite useless in most of use cases.