### PR TITLE
dev-lang/rust-bin: also include stdlib in beta Rust install

### DIFF
--- a/dev-lang/rust-bin/rust-bin-99.ebuild
+++ b/dev-lang/rust-bin/rust-bin-99.ebuild
@@ -37,7 +37,8 @@ src_unpack() {
 }
 
 src_install() {
-	local components=rustc
+	local std=$(grep 'std' ./components)
+	local components="rustc,${std}"
 	use doc && components="${components},rust-docs"
 	./install.sh \
 		--components="${components}" \

--- a/dev-lang/rust-bin/rust-bin-999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-999.ebuild
@@ -37,7 +37,7 @@ src_unpack() {
 }
 
 src_install() {
-	local std=$(./install.sh --list-components | grep 'std' | sed -e 's/^\* //')
+	local std=$(grep 'std' ./components)
 	local components="rustc,${std}"
 	use doc && components="${components},rust-docs"
 	./install.sh \


### PR DESCRIPTION
About
>very bad practics to use `grep` in ebuilds

Another way is:
```bash
while IFS='' read -r line || [[ -n "$line" ]]; do
	case "$line" in
		*std*)
			local std="$line"
		;;
esac
done < "./components"
```
Also, I grepped through `/usr/portage` and found many ebuilds which use `grep`, including `sudo`, `grub` and `python`