### PR TITLE
dev-lang/rust: fix llvm dependency

### DIFF
--- a/dev-lang/rust/rust-1.7.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.7.0-r1.ebuild
@@ -35,15 +35,14 @@ KEYWORDS="~amd64 ~x86"
 IUSE="clang debug doc libcxx +system-llvm"
 REQUIRED_USE="libcxx? ( clang )"
 
-COMMON_DEPEND="libcxx? ( sys-libs/libcxx )
-	system-llvm? ( >=sys-devel/llvm-3.6.0:=[multitarget]
-		<sys-devel/llvm-3.7.0:=[multitarget] )
-"
+COMMON_DEPEND="libcxx? ( sys-libs/libcxx )"
 
 DEPEND="${COMMON_DEPEND}
 	${PYTHON_DEPS}
 	>=dev-lang/perl-5.0
 	clang? ( sys-devel/clang )
+	system-llvm? ( >=sys-devel/llvm-3.6.0[multitarget]
+		<sys-devel/llvm-3.7.0[multitarget] )
 "
 
 RDEPEND="${COMMON_DEPEND}"


### PR DESCRIPTION
Technically prior to LLVM 3.7, Gentoo still supports static linking which
is what the Rust build does by default so LLVM is not a run-time depend.

Package-Manager: portage-2.2.26
Manifest-Sign-Key: 0xA2BC03DC87ED1BD4!
Signed-off-by: Doug Goldstein <cardoe@gentoo.org>