### PR TITLE
bump virtual/rust to 1.8.0

### DIFF
--- a/virtual/rust/rust-1.8.0.ebuild
+++ b/virtual/rust/rust-1.8.0.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+DESCRIPTION="Virtual for Rust language compiler"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE=""
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=""
+RDEPEND="|| (
+	=dev-lang/rust-${PV}*
+	=dev-lang/rust-bin-${PV}*
+)"


### PR DESCRIPTION
Unable to install rust-1.8.0 with installed cargo otherwise.

Cargo depends on virtual/rust, but rust itself does not.