### PR TITLE
dev-lang/rust: it's called get-stage0 now

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -40,7 +40,7 @@ src_unpack() {
 		cd ${S} && \
 		mkdir -p "${S}/dl" && \
 		mkdir -p "${S}/${BUILD_TRIPLE}/stage0/bin" && \
-		python2 "${S}/src/etc/get-snapshot.py" ${BUILD_TRIPLE} || die
+		python2 "${S}/src/etc/get-stage0.py" ${BUILD_TRIPLE} || die
 }
 
 src_prepare() {


### PR DESCRIPTION
Fixes https://github.com/gentoo/gentoo-rust/issues/186.