### PR TITLE
dev-lang/rust: Fix dependency on sys-devel/llvm post 3.7.0

### DIFF
--- a/dev-lang/rust/rust-1.9.0.ebuild
+++ b/dev-lang/rust/rust-1.9.0.ebuild
@@ -52,7 +52,8 @@ DEPEND="${RDEPEND}
 	>=dev-lang/perl-5.0
 	clang? ( sys-devel/clang )
 	system-llvm? ( >=sys-devel/llvm-3.6.0[multitarget]
-		<sys-devel/llvm-3.7.0[multitarget] )
+		!=sys-devel/llvm-3.7.0*
+		<sys-devel/llvm-3.9.0[multitarget] )
 "
 
 PDEPEND=">=app-eselect/eselect-rust-0.3_pre20150425"


### PR DESCRIPTION
LLVM 3.7.0 broke API and ABI compatibility with previous and subsequent
versions, preventing its use with Rust. Version 3.7.1 fixed that
breakage. As such, Rust with USE=system-llvm can now use LLVM from 3.6.0
through at least 3.8.0, with the exception of 3.7.0.