### PR TITLE
Add libressl USE flag #188

### DIFF
--- a/dev-util/cargo/cargo-0.9.0.ebuild
+++ b/dev-util/cargo/cargo-0.9.0.ebuild
@@ -88,10 +88,11 @@ LICENSE="|| ( MIT Apache-2.0 )"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-IUSE="doc test"
+IUSE="doc test libressl"
 
 COMMON_DEPEND="sys-libs/zlib
-	dev-libs/openssl:*
+	!libressl? ( dev-libs/openssl:* )
+	libressl? ( dev-libs/libressl:0 )
 	net-libs/libssh2
 	net-libs/http-parser"
 RDEPEND="${COMMON_DEPEND}

--- a/dev-util/cargo/cargo-9999.ebuild
+++ b/dev-util/cargo/cargo-9999.ebuild
@@ -13,13 +13,14 @@ LICENSE="|| ( MIT Apache-2.0 )"
 SLOT="0"
 KEYWORDS=""
 
-IUSE=""
+IUSE="libressl"
 
 EGIT_REPO_URI="https://github.com/rust-lang/cargo.git"
 
 COMMON_DEPEND=">=virtual/rust-999
 	sys-libs/zlib
-	dev-libs/openssl:*
+	!libressl? ( dev-libs/openssl:* )
+	libressl? ( dev-libs/libressl:0 )
 	net-libs/libssh2
 	net-libs/http-parser"
 RDEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
For the latest cargo version in this repo (0.9) and the git build.
Same thing would probably work for older versions, but I figure there's probably not much point to it.

Closes #188 