### PR TITLE
Add source use flag for racer completion

### DIFF
--- a/dev-lang/rust/rust-1.11.0.ebuild
+++ b/dev-lang/rust/rust-1.11.0.ebuild
@@ -33,7 +33,7 @@ SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.gz"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 
-IUSE="clang debug doc libcxx +system-llvm"
+IUSE="clang debug doc libcxx +system-llvm source"
 REQUIRED_USE="libcxx? ( clang )"
 
 RDEPEND="libcxx? ( sys-libs/libcxx )
@@ -137,6 +137,11 @@ src_install() {
 	LDPATH="/usr/$(get_libdir)/${P}"
 	MANPATH="/usr/share/${P}/man"
 	EOF
+	if use source; then
+		cat <<-EOF >> "${T}"/50${P}
+		RUST_SRC_PATH="/usr/share/${P}/src"
+		EOF
+	fi
 	doenvd "${T}"/50${P}
 
 	cat <<-EOF > "${T}/provider-${P}"
@@ -146,6 +151,11 @@ src_install() {
 	dodir /etc/env.d/rust
 	insinto /etc/env.d/rust
 	doins "${T}/provider-${P}"
+
+	if use source; then
+		dodir /usr/share/${P}
+		cp -R ${S}/src ${D}/usr/share/${P}
+	fi
 }
 
 pkg_postinst() {

--- a/dev-lang/rust/rust-1.12.1-r1.ebuild
+++ b/dev-lang/rust/rust-1.12.1-r1.ebuild
@@ -33,7 +33,7 @@ SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.gz"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 
-IUSE="clang debug doc libcxx +system-llvm"
+IUSE="clang debug doc libcxx +system-llvm source"
 REQUIRED_USE="libcxx? ( clang )"
 
 RDEPEND="libcxx? ( sys-libs/libcxx )
@@ -136,6 +136,11 @@ src_install() {
 	LDPATH="/usr/$(get_libdir)/${P}"
 	MANPATH="/usr/share/${P}/man"
 	EOF
+	if use source; then
+		cat <<-EOF >> "${T}"/50${P}
+		RUST_SRC_PATH="/usr/share/${P}/src"
+		EOF
+	fi
 	doenvd "${T}"/50${P}
 
 	cat <<-EOF > "${T}/provider-${P}"
@@ -145,6 +150,11 @@ src_install() {
 	dodir /etc/env.d/rust
 	insinto /etc/env.d/rust
 	doins "${T}/provider-${P}"
+
+	if use source; then
+		dodir /usr/share/${P}
+		cp -R ${S}/src ${D}/usr/share/${P}
+	fi
 }
 
 pkg_postinst() {

--- a/dev-lang/rust/rust-99.ebuild
+++ b/dev-lang/rust/rust-99.ebuild
@@ -18,7 +18,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="beta"
 KEYWORDS=""
 
-IUSE="clang debug doc libcxx"
+IUSE="clang debug doc libcxx source"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -97,6 +97,11 @@ src_install() {
 	LDPATH="/usr/$(get_libdir)/${P}"
 	MANPATH="/usr/share/${P}/man"
 	EOF
+	if use source; then
+		cat <<-EOF >> "${T}"/50${P}
+		RUST_SRC_PATH="/usr/share/${P}/src"
+		EOF
+	fi
 	doenvd "${T}"/50${P}
 
 	cat <<-EOF > "${T}/provider-${P}"
@@ -106,6 +111,11 @@ src_install() {
 	dodir /etc/env.d/rust
 	insinto /etc/env.d/rust
 	doins "${T}/provider-${P}"
+
+	if use source; then
+		dodir /usr/share/${P}
+		cp -R ${S}/src ${D}/usr/share/${P}
+	fi
 }
 
 pkg_postinst() {

--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -18,7 +18,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="nightly"
 KEYWORDS=""
 
-IUSE="clang debug doc libcxx"
+IUSE="clang debug doc libcxx source"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -97,6 +97,11 @@ src_install() {
 	LDPATH="/usr/$(get_libdir)/${P}"
 	MANPATH="/usr/share/${P}/man"
 	EOF
+	if use source; then
+		cat <<-EOF >> "${T}"/50${P}
+		RUST_SRC_PATH="/usr/share/${P}/src"
+		EOF
+	fi
 	doenvd "${T}"/50${P}
 
 	cat <<-EOF > "${T}/provider-${P}"
@@ -106,6 +111,11 @@ src_install() {
 	dodir /etc/env.d/rust
 	insinto /etc/env.d/rust
 	doins "${T}/provider-${P}"
+
+	if use source; then
+		dodir /usr/share/${P}
+		cp -R ${S}/src ${D}/usr/share/${P}
+	fi
 }
 
 pkg_postinst() {

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="git"
 KEYWORDS=""
 
-IUSE="clang debug doc libcxx"
+IUSE="clang debug doc libcxx source"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -88,6 +88,11 @@ src_install() {
 	LDPATH="/usr/$(get_libdir)/${P}"
 	MANPATH="/usr/share/${P}/man"
 	EOF
+	if use source; then
+		cat <<-EOF >> "${T}"/50${P}
+		RUST_SRC_PATH="/usr/share/${P}/src"
+		EOF
+	fi
 	doenvd "${T}"/50${P}
 
 	cat <<-EOF > "${T}/provider-${P}"
@@ -97,6 +102,11 @@ src_install() {
 	dodir /etc/env.d/rust
 	insinto /etc/env.d/rust
 	doins "${T}/provider-${P}"
+
+	if use source; then
+		dodir /usr/share/${P}
+		cp -R ${S}/src ${D}/usr/share/${P}
+	fi
 }
 
 pkg_postinst() {


### PR DESCRIPTION
This commit adds a `source` use flag to dev-lang/rust ebuilds, which installs the rust source in `/usr/share/${P}/src`. This is useful for other packages such as dev-util/racer, keeping the sources in sync with the installed libs. In support of that, this commit also exports the location of the source install to the environment variable racer looks for.

This was requested in #149.