### PR TITLE
Fixes for workdir and to allow build with shared libraries of system-llvm

### DIFF
--- a/dev-lang/rust/rust-99.ebuild
+++ b/dev-lang/rust/rust-99.ebuild
@@ -45,6 +45,7 @@ S="${WORKDIR}/${MY_P}"
 src_unpack() {
 	wget "${MY_SRC_URI}" || die
 	unpack ./"${MY_P}-src.tar.gz"
+	mv "${MY_P}-src" "${MY_P}"
 
 	use amd64 && BUILD_TRIPLE=x86_64-unknown-linux-gnu
 	use x86 && BUILD_TRIPLE=i686-unknown-linux-gnu
@@ -68,6 +69,7 @@ src_prepare() {
 
 src_configure() {
 	export CFG_DISABLE_LDCONFIG="notempty"
+	export LLVM_LINK_SHARED=1
 	"${ECONF_SOURCE:-.}"/configure \
 		--prefix="${EPREFIX}/usr" \
 		--libdir="${EPREFIX}/usr/$(get_libdir)/${P}" \


### PR DESCRIPTION
I'm almost sure that my hacks is not a good thing to do, but they allowed me to build dev-lang/rust-99. I'm sending pull-request in hope it helps you to figure out the right way to deal with issues I discovered.

This patch solves two issues. The first one is not matching names of real directory with sources and content of $MY_P. I done it by simple `mv'.

The second issue is missing /usr/lib64/libLLVM*.a files, for example: /usr/lib64/libLLVMSupport.a.
I have found that build script (/var/tmp/portage/dev-lang/rust-99/work/rustc-beta/src/librustc_llvm/build.rs) runs llvm-config with option --link-static, but this doesn't work. At least while combined with USE=system-llvm. Those build.rs checks for LLVM_LINK_SHARED environment variable (at least for some versions of llvm), and exporting it solves issue.
