### PR TITLE
Use the new rustbuild build system

### DIFF
--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -2,23 +2,32 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils multilib python-any-r1
+inherit eutils git-r3 multilib python-any-r1
 
-MY_P=rustc-nightly
+if [[ ${PV} = 9999 ]]; then
+	SLOT="git"
+	release_channel="dev"
+	MY_P="rust-git"
+	EGIT_REPO_URI="https://github.com/rust-lang/rust.git"
+	EGIT_CHECKOUT_DIR="${MY_P}-src"
+else
+	SLOT="nightly"
+	release_channel="${SLOT}"
+	MY_P="rustc-nightly"
+	MY_SRC_URI="http://static.rust-lang.org/dist/${MY_P}-src.tar.gz"
+fi
 
 DESCRIPTION="Systems programming language from Mozilla"
 HOMEPAGE="http://www.rust-lang.org/"
-MY_SRC_URI="http://static.rust-lang.org/dist/${MY_P}-src.tar.gz"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
-SLOT="nightly"
 KEYWORDS=""
 
-IUSE="clang debug doc libcxx source"
+IUSE="clang debug doc libcxx source +system-llvm"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -34,36 +43,40 @@ DEPEND="${CDEPEND}
 RDEPEND="${CDEPEND}
 "
 
-S="${WORKDIR}/${MY_P}"
+S="${WORKDIR}/${MY_P}-src"
 
 src_unpack() {
-	wget "${MY_SRC_URI}" || die
-	unpack ./"${MY_P}-src.tar.gz"
+	if [[ ${PV} = 9999 ]]; then
+		git-r3_src_unpack
+	else
+		wget "${MY_SRC_URI}" || die
+		unpack ./"${MY_P}-src.tar.gz"
+	fi
 
 	use amd64 && BUILD_TRIPLE=x86_64-unknown-linux-gnu
 	use x86 && BUILD_TRIPLE=i686-unknown-linux-gnu
-	export CFG_SRC_DIR="${S}" && \
-		cd ${S} && \
-		mkdir -p "${S}/dl" && \
-		mkdir -p "${S}/${BUILD_TRIPLE}/stage0/bin" && \
-		python2 "${S}/src/etc/get-stage0.py" ${BUILD_TRIPLE} || die
-}
-
-src_prepare() {
-	local postfix="gentoo-${SLOT}"
-	sed -i -e "s/CFG_FILENAME_EXTRA=.*/CFG_FILENAME_EXTRA=${postfix}/" mk/main.mk || die
-	find mk -name '*.mk' -exec \
-		 sed -i -e "s/-Werror / /g" {} \; || die
 }
 
 src_configure() {
 	export CFG_DISABLE_LDCONFIG="notempty"
+
+	local postfix="gentoo-${SLOT}"
+	local stagename="RUST_STAGE0_${ARCH}"
+	local stage0="${!stagename}"
+
 	"${ECONF_SOURCE:-.}"/configure \
 		--prefix="${EPREFIX}/usr" \
 		--libdir="${EPREFIX}/usr/$(get_libdir)/${P}" \
 		--mandir="${EPREFIX}/usr/share/${P}/man" \
-		--release-channel=${SLOT} \
+		--release-channel=${release_channel%%/*} \
+		--extra-filename=${postfix} \
 		--disable-manage-submodules \
+		--disable-rustbuild \
+		--default-linker=$(tc-getBUILD_CC) \
+		--default-ar=$(tc-getBUILD_AR) \
+		--python=${EPYTHON} \
+		--disable-rpath \
+		--build=${BUILD_TRIPLE} \
 		$(use_enable clang) \
 		$(use_enable debug) \
 		$(use_enable debug llvm-assertions) \
@@ -107,6 +120,7 @@ src_install() {
 	cat <<-EOF > "${T}/provider-${P}"
 	/usr/bin/rustdoc
 	/usr/bin/rust-gdb
+	/usr/bin/rust-lldb
 	EOF
 	dodir /etc/env.d/rust
 	insinto /etc/env.d/rust


### PR DESCRIPTION
Upstream has dropped support for the old Makefile build system for the newer rustbuild build system. This commit changes the ebuilds of the `git` and `nightly` slots to make use of it.

This also adds the `+system-llvm` use flag to both ebuilds that the official dev-lang/rust package permits. It currently does nothing due to an issue with `llvm-config`, but I'll be looking into that.

Finally, this makes both rust-999.ebuild and rust-9999.ebuild identical in content. I figure nightlies and the direct git upstream should not differ in the build process at all, so we can just check the slot we're installing for and change a few variables to differ between them.