### PR TITLE
Link to llvm dynamically when using system-llvm

### DIFF
--- a/dev-lang/rust/rust-1.12.1-r1.ebuild
+++ b/dev-lang/rust/rust-1.12.1-r1.ebuild
@@ -85,6 +85,13 @@ src_configure() {
 			die "Incompatible rust selected"
 	esac
 
+	# We need to ask llvm-config to link to dynamic libraries
+	# because LLVM ebuild does not provide an option
+	# to compile static libraries
+	if use system-llvm; then
+		export LLVM_LINK_SHARED=1
+	fi
+
 	export CFG_DISABLE_LDCONFIG="notempty"
 
 	"${ECONF_SOURCE:-.}"/configure \

--- a/dev-lang/rust/rust-1.13.0.ebuild
+++ b/dev-lang/rust/rust-1.13.0.ebuild
@@ -67,6 +67,13 @@ src_prepare() {
 }
 
 src_configure() {
+	# We need to ask llvm-config to link to dynamic libraries
+	# because LLVM ebuild does not provide an option
+	# to compile static libraries
+	if use system-llvm; then
+		export LLVM_LINK_SHARED=1
+	fi
+
 	export CFG_DISABLE_LDCONFIG="notempty"
 
 	local stagename="RUST_STAGE0_${ARCH}"

--- a/dev-lang/rust/rust-1.14.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.14.0-r1.ebuild
@@ -66,6 +66,13 @@ src_prepare() {
 }
 
 src_configure() {
+	# We need to ask llvm-config to link to dynamic libraries
+	# because LLVM ebuild does not provide an option
+	# to compile static libraries
+	if use system-llvm; then
+		export LLVM_LINK_SHARED=1
+	fi
+
 	export CFG_DISABLE_LDCONFIG="notempty"
 
 	local stagename="RUST_STAGE0_${ARCH}"

--- a/dev-lang/rust/rust-1.14.0.ebuild
+++ b/dev-lang/rust/rust-1.14.0.ebuild
@@ -66,6 +66,13 @@ src_prepare() {
 }
 
 src_configure() {
+	# We need to ask llvm-config to link to dynamic libraries
+	# because LLVM ebuild does not provide an option
+	# to compile static libraries
+	if use system-llvm; then
+		export LLVM_LINK_SHARED=1
+	fi
+
 	export CFG_DISABLE_LDCONFIG="notempty"
 
 	local stagename="RUST_STAGE0_${ARCH}"

--- a/dev-lang/rust/rust-99.ebuild
+++ b/dev-lang/rust/rust-99.ebuild
@@ -68,6 +68,13 @@ src_prepare() {
 }
 
 src_configure() {
+	# We need to ask llvm-config to link to dynamic libraries
+	# because LLVM ebuild does not provide an option
+	# to compile static libraries
+	if use system-llvm; then
+		export LLVM_LINK_SHARED=1
+	fi
+
 	export CFG_DISABLE_LDCONFIG="notempty"
 	export LLVM_LINK_SHARED=1
 	"${ECONF_SOURCE:-.}"/configure \

--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -58,6 +58,13 @@ src_unpack() {
 }
 
 src_configure() {
+	# We need to ask llvm-config to link to dynamic libraries
+	# because LLVM ebuild does not provide an option
+	# to compile static libraries
+	if use system-llvm; then
+		export LLVM_LINK_SHARED=1
+	fi
+
 	export CFG_DISABLE_LDCONFIG="notempty"
 
 	local postfix="gentoo-${SLOT}"

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -69,6 +69,13 @@ src_prepare() {
 }
 
 src_configure() {
+	# We need to ask llvm-config to link to dynamic libraries
+	# because LLVM ebuild does not provide an option
+	# to compile static libraries
+	if use system-llvm; then
+		export LLVM_LINK_SHARED=1
+	fi
+
 	export CFG_DISABLE_LDCONFIG="notempty"
 
 	local postfix="gentoo-${SLOT}"


### PR DESCRIPTION
We need to ask `llvm-config` to link to dynamic libraries (it tries to find static libraries by default) because LLVM ebuild does not provide an option to compile static libraries, this PR finally allows to use the `system-llvm` flag.