### PR TITLE
dev-util/cargo-bin: Fix bash_completion installation

### DIFF
--- a/dev-util/cargo-bin/cargo-bin-99.ebuild
+++ b/dev-util/cargo-bin/cargo-bin-99.ebuild
@@ -47,6 +47,6 @@ src_install() {
 
 	dosym "/opt/${P}/bin/cargo" /usr/bin/cargo
 	dosym "/opt/${P}/share/zsh/site-functions/_cargo" /usr/share/zsh/site-functions/_cargo
-	newbashcomp "${D}/opt/${P}/etc/bash_completion.d/cargo" cargo
+	newbashcomp "${D}/opt/${P}/etc/bash_completions.d/cargo" cargo
 	rm -rf "${D}/opt/${P}/etc" || die
 }

--- a/dev-util/cargo-bin/cargo-bin-999.ebuild
+++ b/dev-util/cargo-bin/cargo-bin-999.ebuild
@@ -47,6 +47,6 @@ src_install() {
 
 	dosym "/opt/${P}/bin/cargo" /usr/bin/cargo
 	dosym "/opt/${P}/share/zsh/site-functions/_cargo" /usr/share/zsh/site-functions/_cargo
-	newbashcomp "${D}/opt/${P}/etc/bash_completion.d/cargo" cargo
+	newbashcomp "${D}/opt/${P}/etc/bash_completions.d/cargo" cargo
 	rm -rf "${D}/opt/${P}/etc" || die
 }


### PR DESCRIPTION
Fix changing directory name: `bash_completion.d` to `bash_completions.d`.