### PR TITLE
dev-lang/rust: Fix configuration after removing --enable-save-analysis flag.

### DIFF
--- a/dev-lang/rust/metadata.xml
+++ b/dev-lang/rust/metadata.xml
@@ -17,6 +17,6 @@
     <flag name="system-llvm">Use system <pkg>sys-devel/llvm</pkg> in
     place of the bundled one</flag>
     <flag name="sanitize">Add LeakSanitizer, ThreadSanitizer, AddressSanitizer and MemorySanitizer support</flag>
-    <flag name="analysis">Install standard library analysis data used by Rust Language Server</flag>
+    <flag name="tools">Enable a build of the and extended rust tool (RLS, analysis data, ...)</flag>
   </use>
 </pkgmetadata>

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -27,7 +27,7 @@ HOMEPAGE="http://www.rust-lang.org/"
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 KEYWORDS=""
 
-IUSE="clang debug doc libcxx source +system-llvm sanitize analysis"
+IUSE="clang debug doc libcxx source +system-llvm sanitize tools"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -105,7 +105,7 @@ src_configure() {
 		$(use_enable libcxx libcpp) \
 		$(use_enable sanitize sanitizers) \
 		$(usex system-llvm "--llvm-root=${EPREFIX}/usr" " ") \
-		$(use_enable analysis save-analysis) \
+		$(use_enable tools extended) \
 		|| die
 }
 
@@ -150,12 +150,6 @@ src_install() {
 	if use source; then
 		dodir /usr/share/${P}
 		cp -R "${S}/src" "${D}/usr/share/${P}"
-	fi
-
-	if use debug; then
-		TARGET=debug
-	else
-		TARGET=release
 	fi
 }
 


### PR DESCRIPTION
Fix configuration after merging PR https://github.com/rust-lang/rust/pull/40584

Remove `analysis` flag and use `tools` as it manages other tools too.