### PR TITLE
LLVM 4+ now has it's own dir at /usr/lib/llvm/N

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -104,7 +104,7 @@ src_configure() {
 		$(use_enable doc docs) \
 		$(use_enable libcxx libcpp) \
 		$(use_enable sanitize sanitizers) \
-		$(usex system-llvm "--llvm-root=${EPREFIX}/usr" " ") \
+		$(usex system-llvm "--llvm-root=${EPREFIX}$(llvm-config --obj-root)" " ") \
 		$(use_enable tools extended) \
 		|| die
 }


### PR DESCRIPTION
Therefore the root is now there and `llvm-config --obj-root` knows about it