### PR TITLE
Remove doc path fixup for rust-1.18.0.ebuild

### DIFF
--- a/dev-lang/rust/rust-1.18.0.ebuild
+++ b/dev-lang/rust/rust-1.18.0.ebuild
@@ -147,12 +147,6 @@ src_install() {
 
 	dodoc COPYRIGHT
 
-	if use doc ; then
-		dodir "/usr/share/doc/rust-${PV}/"
-		mv "${D}/usr/share/doc/rust"/* "${D}/usr/share/doc/rust-${PV}/" || die
-		rmdir "${D}/usr/share/doc/rust/" || die
-	fi
-
 	cat <<-EOF > "${T}"/50${P}
 		MANPATH="/usr/share/${P}/man"
 	EOF


### PR DESCRIPTION
When emerging =dev-lang/rust-1.18.0[doc], the merge fails on l.152 of the ebuild: the source path is not found.
Indeed all doc files are already in _"${D}/usr/share/doc/rust-1.18.0/"_, and do not need to be moved.