### PR TITLE
dev-lang/rust-9999: Remove cargo if build with tools enabled.

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -107,6 +107,15 @@ src_install() {
 	mv "${D}/usr/bin/rustdoc" "${D}/usr/bin/rustdoc-${PV}" || die
 	mv "${D}/usr/bin/rust-gdb" "${D}/usr/bin/rust-gdb-${PV}" || die
 	mv "${D}/usr/bin/rust-lldb" "${D}/usr/bin/rust-lldb-${PV}" || die
+	if use tools; then
+		mv "${D}/usr/bin/rls" "${D}/usr/bin/rls-${PV}" || die
+		# remove cargo
+		rm -f "${D}/usr/bin/cargo" || die
+		rm -f "${D}/usr/share/zsh/site-functions/_cargo" || die
+		rm -f "${D}/usr/share/rust-9999/man/man1/cargo*" || die
+		rm -f "${D}/etc/bash_completion.d/cargo" || die
+		rm -f "${D}/usr/lib64/rust-9999/rustlib/manifest-cargo" || die
+	fi
 
 	dodoc COPYRIGHT LICENSE-APACHE LICENSE-MIT
 


### PR DESCRIPTION
Fix #255 . It's just deletes `cargo` file after installation.
May be it better to have `virtual/cargo` to allow `cargo` from `dev-lang/rust[tools]` or disable some step to avoid `cargo` installation.