### PR TITLE
dev-rust/rust-bindgen is broken due to non existing repository

### DIFF
--- a/dev-rust/rust-bindgen/rust-bindgen-9999.ebuild
+++ b/dev-rust/rust-bindgen/rust-bindgen-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils git-r3
 
 DESCRIPTION="A binding generator for the rust language"
-HOMEPAGE="https://github.com/crabtw/rust-bindgen"
+HOMEPAGE="https://github.com/servo/rust-bindgen"
 
 LICENSE="BSD"
 SLOT="0"
@@ -14,7 +14,7 @@ KEYWORDS=""
 
 IUSE=""
 
-EGIT_REPO_URI="https://github.com/crabtw/rust-bindgen.git"
+EGIT_REPO_URI="https://github.com/servo/rust-bindgen.git"
 
 DEPEND=">=virtual/rust-999
 	dev-util/cargo


### PR DESCRIPTION
The GitHub repository in the ebuild is no longer available and was replaced by the current one.