### PR TITLE
Disable rpath after https://github.com/rust-lang/rust/pull/43694

### DIFF
--- a/dev-lang/rust/rust-9999-r1.ebuild
+++ b/dev-lang/rust/rust-9999-r1.ebuild
@@ -125,7 +125,7 @@ src_configure() {
 		use-jemalloc = true
 		default-linker = "${linker}"
 		default-ar = "${archiver}"
-		rpath = true
+		rpath = false
 		[target.${rust_target}]
 		cc = "${c_compiler}"
 		cxx = "${cxx_compiler}"


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/43694 fixed error when building rustdoc without rpath. Now it possible to disable rpath.