### PR TITLE
Fix #287 and restore git data.

### DIFF
--- a/dev-lang/rust/rust-9999-r1.ebuild
+++ b/dev-lang/rust/rust-9999-r1.ebuild
@@ -115,7 +115,7 @@ src_configure() {
 		extended = $(toml_usex tools)
 		[install]
 		prefix = "${EPREFIX}/usr"
-		libdir = "$(get_libdir)"
+		libdir = "$(get_libdir)/${P}"
 		docdir = "share/doc/${P}"
 		mandir = "share/${P}/man"
 		[rust]
@@ -126,6 +126,7 @@ src_configure() {
 		default-linker = "${linker}"
 		default-ar = "${archiver}"
 		rpath = false
+		ignore-git = false
 		[target.${rust_target}]
 		cc = "${c_compiler}"
 		cxx = "${cxx_compiler}"


### PR DESCRIPTION
Fixes #287.
Fix git commit hash and date in a verbose version.