### PR TITLE
Use https when downloading sources.

### DIFF
--- a/dev-lang/rust-bin/rust-bin-99.ebuild
+++ b/dev-lang/rust-bin/rust-bin-99.ebuild
@@ -7,7 +7,7 @@ inherit eutils bash-completion-r1
 
 DESCRIPTION="Systems programming language from Mozilla"
 HOMEPAGE="http://www.rust-lang.org/"
-MY_SRC_URI="http://static.rust-lang.org/dist/rust-beta"
+MY_SRC_URI="https://static.rust-lang.org/dist/rust-beta"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="beta"

--- a/dev-lang/rust-bin/rust-bin-999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-999.ebuild
@@ -7,7 +7,7 @@ inherit eutils bash-completion-r1
 
 DESCRIPTION="Systems programming language from Mozilla"
 HOMEPAGE="http://www.rust-lang.org/"
-MY_SRC_URI="http://static.rust-lang.org/dist/rust-nightly"
+MY_SRC_URI="https://static.rust-lang.org/dist/rust-nightly"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="nightly"

--- a/dev-util/cargo-bin/cargo-bin-99.ebuild
+++ b/dev-util/cargo-bin/cargo-bin-99.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1
 
 DESCRIPTION="The Rust's package manager"
 HOMEPAGE="http://crates.io"
-MY_SRC_URI="http://static.rust-lang.org/dist/rust-beta"
+MY_SRC_URI="https://static.rust-lang.org/dist/rust-beta"
 
 LICENSE="|| ( MIT Apache-2.0 )"
 SLOT="0"

--- a/dev-util/cargo-bin/cargo-bin-999.ebuild
+++ b/dev-util/cargo-bin/cargo-bin-999.ebuild
@@ -7,7 +7,7 @@ inherit bash-completion-r1
 
 DESCRIPTION="The Rust's package manager"
 HOMEPAGE="http://crates.io"
-MY_SRC_URI="http://static.rust-lang.org/dist/rust-nightly"
+MY_SRC_URI="https://static.rust-lang.org/dist/rust-nightly"
 
 LICENSE="|| ( MIT Apache-2.0 )"
 SLOT="0"

--- a/dev-util/cargo/cargo-9999.ebuild
+++ b/dev-util/cargo/cargo-9999.ebuild
@@ -15,7 +15,7 @@ KEYWORDS=""
 IUSE="libressl"
 
 EGIT_REPO_URI="https://github.com/rust-lang/cargo.git"
-BIN_CARGO_URI="http://static.rust-lang.org/dist/cargo-nightly"
+BIN_CARGO_URI="https://static.rust-lang.org/dist/cargo-nightly"
 
 COMMON_DEPEND=">=virtual/rust-999
 	sys-libs/zlib


### PR DESCRIPTION
These beta and nightly versions are downloaded with wget and they do not have any checksum checks. Better use https.