### PR TITLE
dev-util/cargo-bin: Fix bash_completion dir

### DIFF
--- a/dev-util/cargo-bin/cargo-bin-99.ebuild
+++ b/dev-util/cargo-bin/cargo-bin-99.ebuild
@@ -46,6 +46,6 @@ src_install() {
 
 	dosym "/opt/${P}/bin/cargo" /usr/bin/cargo
 	dosym "/opt/${P}/share/zsh/site-functions/_cargo" /usr/share/zsh/site-functions/_cargo
-	newbashcomp "${D}/opt/${P}/etc/bash_completions.d/cargo" cargo
+	newbashcomp "${D}/opt/${P}/etc/bash_completion.d/cargo" cargo
 	rm -rf "${D}/opt/${P}/etc" || die
 }

--- a/dev-util/cargo-bin/cargo-bin-999.ebuild
+++ b/dev-util/cargo-bin/cargo-bin-999.ebuild
@@ -46,6 +46,6 @@ src_install() {
 
 	dosym "/opt/${P}/bin/cargo" /usr/bin/cargo
 	dosym "/opt/${P}/share/zsh/site-functions/_cargo" /usr/share/zsh/site-functions/_cargo
-	newbashcomp "${D}/opt/${P}/etc/bash_completions.d/cargo" cargo
+	newbashcomp "${D}/opt/${P}/etc/bash_completion.d/cargo" cargo
 	rm -rf "${D}/opt/${P}/etc" || die
 }


### PR DESCRIPTION
Rust has changed the bash completion dir in
https://github.com/rust-lang/rust/commit/dda2d756facc1c8100261e2ebd4e115c84f515cc