### PR TITLE
Create 0001-librustc_llvm-build-Force-link-against-libffi.patch

### DIFF
--- a/dev-lang/rust/files/0001-librustc_llvm-build-Force-link-against-libffi.patch
+++ b/dev-lang/rust/files/0001-librustc_llvm-build-Force-link-against-libffi.patch
@@ -1,0 +1,31 @@
+From 5dbc650a60ddb230f59e5a18ffd298b033566945 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Johannes=20L=C3=B6thberg?= <johannes@kyriasis.com>
+Date: Thu, 20 Jul 2017 23:07:01 +0200
+Subject: [PATCH] librustc_llvm/build: Force link against libffi
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+`llvm-config --libs` doesn't output libffi in many cases.  Fixing it
+turned out to take quite a bit of effort, so force libffi linking in
+here for now.
+
+Signed-off-by: Johannes Löthberg <johannes@kyriasis.com>
+---
+ src/librustc_llvm/build.rs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/librustc_llvm/build.rs b/src/librustc_llvm/build.rs
+index 3f0f536960..7dc0c40c9d 100644
+--- a/src/librustc_llvm/build.rs
++++ b/src/librustc_llvm/build.rs
+@@ -220,6 +220,7 @@ fn main() {
+         };
+         println!("cargo:rustc-link-lib={}={}", kind, name);
+     }
++    println!("cargo:rustc-link-lib=dylib=ffi");
+ 
+     // LLVM ldflags
+     //
+-- 
+2.13.3


### PR DESCRIPTION
0001-librustc_llvm-build-Force-link-against-libffi.patch
Close https://github.com/gentoo/gentoo-rust/issues/304