### PR TITLE
Update rust-1.22.1.ebuild

### DIFF
--- a/dev-lang/rust/rust-1.22.1.ebuild
+++ b/dev-lang/rust/rust-1.22.1.ebuild
@@ -43,6 +43,8 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 
 IUSE="debug doc +jemalloc ${ALL_LLVM_TARGETS[*]}"
 
+REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )"
+
 RDEPEND=""
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}


### PR DESCRIPTION
User must define LLVM_TARGETS through use flags
Closes https://github.com/gentoo/gentoo-rust/issues/306