### PR TITLE
dev-util/cargo-9999: fix build

### DIFF
--- a/dev-util/cargo/cargo-9999.ebuild
+++ b/dev-util/cargo/cargo-9999.ebuild
@@ -39,10 +39,11 @@ pkg_setup() {
 
 	wget "${BIN_CARGO_URI}-${postfix}.tar.gz" || die
 	unpack "./cargo-nightly-${postfix}.tar.gz"
+	mv "./cargo-nightly-${postfix}" "./cargo"
 }
 
 src_compile() {
-	cargo build --release || die
+	"$HOME/cargo/cargo/bin/cargo" build --release || die
 }
 
 src_install() {


### PR DESCRIPTION
`cargo` binary was downloaded, but wasn't used, so build worked only if `cargo` was already installed