### PR TITLE
Update rust-1.23.0.ebuild

### DIFF
--- a/dev-lang/rust/rust-1.23.0.ebuild
+++ b/dev-lang/rust/rust-1.23.0.ebuild
@@ -117,7 +117,6 @@ src_configure() {
 		use-jemalloc = $(toml_usex jemalloc)
 		backtrace = $(toml_usex debug)
 		default-linker = "$(tc-getCC)"
-		default-ar = "$(tc-getAR)"
 		channel = "stable"
 		rpath = false
 		codegen-tests = $(toml_usex debug)


### PR DESCRIPTION
error during building. **default-ar** cannot be parsed