### PR TITLE
dev-lang/rust - proper MAKEOPTS handling

### DIFF
--- a/dev-lang/rust/rust-1.22.1.ebuild
+++ b/dev-lang/rust/rust-1.22.1.ebuild
@@ -130,7 +130,7 @@ src_configure() {
 }
 
 src_compile() {
-	./x.py build --verbose --config="${S}"/config.toml ${MAKEOPTS} || die
+	./x.py build --verbose --config="${S}"/config.toml $(echo ${MAKEOPTS} | egrep -o '(\-j|\-\-jobs)(=?|[[:space:]]*)[[:digit:]]+') || die
 }
 
 src_install() {

--- a/dev-lang/rust/rust-1.23.0.ebuild
+++ b/dev-lang/rust/rust-1.23.0.ebuild
@@ -128,7 +128,7 @@ src_configure() {
 }
 
 src_compile() {
-	./x.py build --verbose --config="${S}"/config.toml ${MAKEOPTS} || die
+	./x.py build --verbose --config="${S}"/config.toml $(echo ${MAKEOPTS} | egrep -o '(\-j|\-\-jobs)(=?|[[:space:]]*)[[:digit:]]+') || die
 }
 
 src_install() {

--- a/dev-lang/rust/rust-9999-r1.ebuild
+++ b/dev-lang/rust/rust-9999-r1.ebuild
@@ -151,11 +151,11 @@ src_configure() {
 }
 
 src_compile() {
-	${EPYTHON} x.py build --verbose --config="${S}"/config.toml ${MAKEOPTS} || die
+	${EPYTHON} x.py build --verbose --config="${S}"/config.toml $(echo ${MAKEOPTS} | egrep -o '(\-j|\-\-jobs)(=?|[[:space:]]*)[[:digit:]]+') || die
 }
 
 src_install() {
-	env DESTDIR="${D}" ${EPYTHON} x.py install  --verbose --config="${S}"/config.toml ${MAKEOPTS} || die
+	env DESTDIR="${D}" ${EPYTHON} x.py install  --verbose --config="${S}"/config.toml $(echo ${MAKEOPTS} | egrep -o '(\-j|\-\-jobs)(=?|[[:space:]]*)[[:digit:]]+') || die
 
 	mv "${D}/usr/bin/rustc" "${D}/usr/bin/rustc-${PV}" || die
 	mv "${D}/usr/bin/rustdoc" "${D}/usr/bin/rustdoc-${PV}" || die


### PR DESCRIPTION
The only part of the MAKEOPTS variable that x.py understands is "-j \<number>" or "--jobs \<number>". Something like "-j9 -l9" would break the build, so we extract just what we support from the global variable.