### PR TITLE
dev-util/cargo-0.23.0 - virtual package to fix issue #308

### DIFF
--- a/dev-util/cargo/cargo-0.23.0.ebuild
+++ b/dev-util/cargo/cargo-0.23.0.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="The Rust's package manager (virtual package)"
+HOMEPAGE="http://crates.io"
+SRC_URI=""
+
+LICENSE="|| ( MIT Apache-2.0 )"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=""
+RDEPEND=""
+PDEPEND=">=dev-lang/rust-1.22.1"


### PR DESCRIPTION
\>=dev-lang/rust-1.22.1 cannot be installed at the same time as <=dev-util/cargo-0.22.0
and packages like sys-apps/ripgrep and www-client/firefox have a hard
dependency on dev-util/cargo.

This ugly hack solves the problem of using recent rust versions from the
"rust" overlay at the same time with firefox and/or ripgrep from the
main repo.

This virtual package should be removed in a few years, when Gentoo
developers solve the problem properly by changing the dependencies of
those two packages.