### PR TITLE
Add virtual/rust-9999 to satisfy cargo-9999 dependency

### DIFF
--- a/virtual/rust/rust-9999.ebuild
+++ b/virtual/rust/rust-9999.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+DESCRIPTION="Virtual for Rust language compiler"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE=""
+SLOT="0"
+KEYWORDS=""
+
+DEPEND=""
+RDEPEND="|| ( =dev-lang/rust-${PV}* =dev-lang/rust-bin-${PV}* )"


### PR DESCRIPTION
cargo-9999 depends on >=virtual/rust-999 but there's no >=virtual/rust-999

