### PR TITLE
rust-9999.ebuild: fix usage of usex

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -57,7 +57,7 @@ toml_usex() {
 
 toml_tools_list() {
     if use extended; then
-       echo "tools=[$(usex source "\"src\",") \"rls\", \"analysis\"]"
+       echo "tools=[$(usex source "\"src\", " "")\"rls\", \"analysis\"]"
     fi
 }
 


### PR DESCRIPTION
usex expects 2 arguments and if the second argument is not
given it defaults to "no" causing build to fail when "extended" use-flag
is enabled.
