### PR TITLE
[dev-lang/rust] remove unused flag libcxx

### DIFF
--- a/dev-lang/rust/metadata.xml
+++ b/dev-lang/rust/metadata.xml
@@ -7,8 +7,6 @@
   </maintainer>
   <use>
     <flag name="clang">Use <pkg>sys-devel/clang</pkg> for building</flag>
-    <flag name="libcxx">Use <pkg>sys-libs/libcxx</pkg> as standard
-    library when building with <pkg>sys-devel/clang</pkg></flag>
     <flag name="system-llvm">Use system <pkg>sys-devel/llvm</pkg> in
     place of the bundled one</flag>
     <flag name="jemalloc">Use <pkg>sys-libs/jemalloc</pkg> as the


### PR DESCRIPTION
libcxx is now imported with clang flag