### PR TITLE
Fix clippy compilation.

### DIFF
--- a/dev-util/clippy/clippy-9999.ebuild
+++ b/dev-util/clippy/clippy-9999.ebuild
@@ -16,5 +16,15 @@ SLOT="0"
 KEYWORDS=""
 IUSE=""
 
-DEPEND=""
+DEPEND=">=virtual/rust-9999"
 RDEPEND="${DEPEND}"
+
+src_install() {
+  debug-print-function ${FUNCNAME} "$@"
+
+  cargo install -j $(makeopts_jobs) --root="${D}/usr" --path .  $(usex debug --debug "") \
+    || die "cargo install failed"
+  rm -f "${D}/usr/.crates.toml"
+
+  [ -d "${S}/man" ] && doman "${S}/man" || return 
+}


### PR DESCRIPTION
Fixes error: `error: To build the current package use `cargo build`, to install the current package run `cargo install --path .`, otherwise specify a crate to install from crates.io, or use --path or --git to specify alternate source`