### PR TITLE
Add support for WebAssembly

### DIFF
--- a/dev-lang/rust/metadata.xml
+++ b/dev-lang/rust/metadata.xml
@@ -13,5 +13,6 @@
     <flag name="jemalloc">Use <pkg>sys-libs/jemalloc</pkg> as the
     standard memory allocator</flag>
     <flag name="sanitize">Check for kernel version</flag>
+    <flag name="wasm">Enable WebAssembly support</flag>
   </use>
 </pkgmetadata>


### PR DESCRIPTION
Enables wams32-unknown-unknown target.
Enables installation LLD linker.
Works only with `RUSTFLAGS="-C linker=lld"`. I'm not sure how to fix it.