### PR TITLE
dev-util/cargo-9999: fix build

### DIFF
--- a/dev-util/cargo/cargo-9999.ebuild
+++ b/dev-util/cargo/cargo-9999.ebuild
@@ -11,6 +11,7 @@ HOMEPAGE="http://crates.io/"
 LICENSE="|| ( MIT Apache-2.0 )"
 SLOT="0"
 KEYWORDS=""
+RESTRICT="network-sandbox"
 
 IUSE="libressl"
 


### PR DESCRIPTION
It can't download dependencies if `network-sandbox` feature is enabled.

Fixes #340.