### PR TITLE
Add dev-libs/libsodium to pijul DEPEND

### DIFF
--- a/dev-vcs/pijul/pijul-0.10.0.ebuild
+++ b/dev-vcs/pijul/pijul-0.10.0.ebuild
@@ -213,7 +213,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-DEPEND=""
+DEPEND="dev-libs/libsodium"
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${P}/${PN}"


### PR DESCRIPTION
The thrussh-libsodium crate depends on libsodium. Make sure that
dev-libs/libsodium is a dependency of this ebuild.