### PR TITLE
Add webassembly to rust-bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 python:
     - pypy
 env:
-    - PORTAGE_VER="2.3.38"
+    - PORTAGE_VER="2.3.40"
 before_install:
     - sudo apt-get -qq update
     - pip install lxml pyyaml
@@ -23,8 +23,8 @@ before_script:
     - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
     - echo "portage::250:portage,travis" >> /etc/group
     - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /usr/portage/distfiles/metadata.dtd
-    - ln -s portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
-    - ln -s /usr/portage/profiles/default/linux/amd64/13.0 /etc/portage/make.profile
+    - ln -s $TRAVIS_BUILD_DIR/portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
+    - ln -s /usr/portage/profiles/default/linux/amd64/17.0 /etc/portage/make.profile
     - SIZE=$(stat -c %s .travis.yml.upstream)
     - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
     - cd travis-overlay


### PR DESCRIPTION
Also added "infrastructure" for adding other [platforms](https://forge.rust-lang.org/platform-support.html).

Put `USE_EXPAND="RUSTLIB_TARGETS"` into your `make.conf` to make it look a little nicer.

CC #356.