### PR TITLE
Split extended flags same way as gentoo version

### DIFF
--- a/dev-lang/rust/metadata.xml
+++ b/dev-lang/rust/metadata.xml
@@ -6,13 +6,12 @@
     <name>Rust Project</name>
   </maintainer>
   <use>
-    <flag name="extended">Install extended rust tools (RLS, analysis data, ...)</flag>
-    <flag name="clang">Use <pkg>sys-devel/clang</pkg> for building</flag>
     <flag name="system-llvm">Use system <pkg>sys-devel/llvm</pkg> in
     place of the bundled one</flag>
     <flag name="jemalloc">Use <pkg>sys-libs/jemalloc</pkg> as the
     standard memory allocator</flag>
     <flag name="sanitize">Check for kernel version</flag>
     <flag name="wasm">Enable WebAssembly support</flag>
+    <flag name="clippy">Install clippy</flag>
   </use>
 </pkgmetadata>


### PR DESCRIPTION
Removes `extended` flag. Uses separate flags for tools. Adds flag `clippy`.