### PR TITLE
Updates for =dev-lang/rust-9999

### DIFF
--- a/dev-lang/rust/files/rust-9999-fix-clippy-sysroot.patch
+++ b/dev-lang/rust/files/rust-9999-fix-clippy-sysroot.patch
@@ -1,0 +1,64 @@
+diff --git a/src/driver.rs b/src/driver.rs
+index 99f8bc61..02ffc6db 100644
+--- a/src/tools/clippy/src/driver.rs
++++ b/src/tools/clippy/src/driver.rs
+@@ -29,54 +30,22 @@ pub fn main() {
+             exit(0);
+         }
+ 
+-        let sys_root = option_env!("SYSROOT")
+-            .map(String::from)
+-            .or_else(|| std::env::var("SYSROOT").ok())
+-            .or_else(|| {
+-                let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
+-                let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
+-                home.and_then(|home| toolchain.map(|toolchain| format!("{}/toolchains/{}", home, toolchain)))
+-            })
+-            .or_else(|| {
+-                Command::new("rustc")
+-                    .arg("--print")
+-                    .arg("sysroot")
+-                    .output()
+-                    .ok()
+-                    .and_then(|out| String::from_utf8(out.stdout).ok())
+-                    .map(|s| s.trim().to_owned())
+-            })
+-            .expect("need to specify SYSROOT env var during clippy compilation, or use rustup or multirust");
+-
+         // Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
+         // We're invoking the compiler programmatically, so we ignore this/
+-        let mut orig_args: Vec<String> = env::args().collect();
+-        if orig_args.len() <= 1 {
++        let mut args: Vec<String> = env::args().collect();
++        if args.len() <= 1 {
+             std::process::exit(1);
+         }
+-        if Path::new(&orig_args[1]).file_stem() == Some("rustc".as_ref()) {
++        if Path::new(&args[1]).file_stem() == Some("rustc".as_ref()) {
+             // we still want to be able to invoke it normally though
+-            orig_args.remove(1);
++            args.remove(1);
+         }
+-        // this conditional check for the --sysroot flag is there so users can call
+-        // `clippy_driver` directly
+-        // without having to pass --sysroot or anything
+-        let mut args: Vec<String> = if orig_args.iter().any(|s| s == "--sysroot") {
+-            orig_args.clone()
+-        } else {
+-            orig_args
+-                .clone()
+-                .into_iter()
+-                .chain(Some("--sysroot".to_owned()))
+-                .chain(Some(sys_root))
+-                .collect()
+-        };
+ 
+         // this check ensures that dependencies are built but not linted and the final
+         // crate is
+         // linted but not built
+         let clippy_enabled = env::var("CLIPPY_TESTS").ok().map_or(false, |val| val == "true")
+-            || orig_args.iter().any(|s| s == "--emit=dep-info,metadata");
++            || args.iter().any(|s| s == "--emit=dep-info,metadata");
+ 
+         if clippy_enabled {
+             args.extend_from_slice(&["--cfg".to_owned(), r#"feature="cargo-clippy""#.to_owned()]);


### PR DESCRIPTION
Fix #368. Patch will be removed after https://github.com/rust-lang-nursery/rust-clippy/pull/3257 landed.
Use multiprocess eclass.
RLS requires analysis and sources.
Fix behavior if EPYTHON not found.