### PR TITLE
Use new rust.jemalloc option

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -161,7 +161,7 @@ src_configure() {
 		optimize = $(toml_usex !debug)
 		debuginfo = $(toml_usex debug)
 		debug-assertions = $(toml_usex debug)
-		use-jemalloc = $(toml_usex jemalloc)
+		jemalloc = $(toml_usex jemalloc)
 		default-linker = "$(tc-getCC)"
 		rpath = false
 		ignore-git = false


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/55238 jemalloc is managed with `rust.jemalloc` option.