### PR TITLE
dev-lang/rust-9999: latest fixes

### DIFF
--- a/dev-lang/rust/files/rust-9999-fix-codegen-path.patch
+++ b/dev-lang/rust/files/rust-9999-fix-codegen-path.patch
@@ -1,8 +1,8 @@
 diff --git a/src/librustc/session/filesearch.rs b/src/librustc/session/filesearch.rs
-index c204556d51..8c72869eb1 100644
+index 77f190e281..6388798fef 100644
 --- a/src/librustc/session/filesearch.rs
 +++ b/src/librustc/session/filesearch.rs
-@@ -124,6 +124,13 @@ pub fn make_target_lib_path(sysroot: &Path, target_triple: &str) -> PathBuf {
+@@ -114,6 +114,13 @@ pub fn make_target_lib_path(sysroot: &Path, target_triple: &str) -> PathBuf {
      sysroot.join(&relative_target_lib_path(sysroot, target_triple))
  }
  
@@ -16,12 +16,12 @@ index c204556d51..8c72869eb1 100644
  pub fn get_or_default_sysroot() -> PathBuf {
      // Follow symlinks.  If the resolved path is relative, make it absolute.
      fn canonicalize(path: Option<PathBuf>) -> Option<PathBuf> {
-diff --git a/src/librustc_driver/lib.rs b/src/librustc_driver/lib.rs
-index 5527c0ad38..0f7e0eeaa8 100644
---- a/src/librustc_driver/lib.rs
-+++ b/src/librustc_driver/lib.rs
-@@ -294,37 +294,35 @@ fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
-     }
+diff --git a/src/librustc_interface/util.rs b/src/librustc_interface/util.rs
+index 6f92c30446..50fc59f204 100644
+--- a/src/librustc_interface/util.rs
++++ b/src/librustc_interface/util.rs
+@@ -138,37 +138,35 @@ pub fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend
+             "cannot load the default codegen backend twice");
  
      let target = session::config::host_triple();
 -    let mut sysroot_candidates = vec![filesearch::get_or_default_sysroot()];
@@ -75,7 +75,7 @@ index 5527c0ad38..0f7e0eeaa8 100644
                  option_env!("CFG_CODEGEN_BACKENDS_DIR").unwrap_or("codegen-backends"))
          })
          .filter(|f| {
-@@ -333,12 +331,12 @@ fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
+@@ -177,12 +175,12 @@ pub fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend
          })
          .next();
      let sysroot = sysroot.unwrap_or_else(|| {

--- a/dev-lang/rust/files/rust-9999-fix-rustdoc.patch
+++ b/dev-lang/rust/files/rust-9999-fix-rustdoc.patch
@@ -1,0 +1,84 @@
+diff --git a/src/bootstrap/builder.rs b/src/bootstrap/builder.rs
+index 7e6c0a9f52..bc033bd0bc 100644
+--- a/src/bootstrap/builder.rs
++++ b/src/bootstrap/builder.rs
+@@ -677,9 +677,10 @@ impl<'a> Builder<'a> {
+         let compiler = self.compiler(self.top_stage, host);
+         cmd.env("RUSTC_STAGE", compiler.stage.to_string())
+             .env("RUSTC_SYSROOT", self.sysroot(compiler))
+-            // Note that this is *not* the sysroot_libdir because rustdoc must be linked
+-            // equivalently to rustc.
+-            .env("RUSTDOC_LIBDIR", self.rustc_libdir(compiler))
++            .env(
++                "RUSTDOC_LIBDIR",
++                self.sysroot_libdir(compiler, self.config.build),
++            )
+             .env("CFG_RELEASE_CHANNEL", &self.config.channel)
+             .env("RUSTDOC_REAL", self.rustdoc(host))
+             .env("RUSTDOC_CRATE_VERSION", self.rust_version())
+@@ -873,7 +874,7 @@ impl<'a> Builder<'a> {
+         } else {
+             &maybe_sysroot
+         };
+-        let libdir = self.rustc_libdir(compiler);
++        let libdir = sysroot.join(libdir(&compiler.host));
+ 
+         // Customize the compiler we're running. Specify the compiler to cargo
+         // as our shim and then pass it some various options used to configure
+@@ -915,7 +916,7 @@ impl<'a> Builder<'a> {
+             cargo.env("RUSTC_ERROR_FORMAT", error_format);
+         }
+         if cmd != "build" && cmd != "check" && cmd != "rustc" && want_rustdoc {
+-            cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(compiler));
++            cargo.env("RUSTDOC_LIBDIR", self.sysroot_libdir(compiler, self.config.build));
+         }
+ 
+         if mode.is_tool() {
+diff --git a/src/bootstrap/tool.rs b/src/bootstrap/tool.rs
+index fc1a17d546..021c9f3656 100644
+--- a/src/bootstrap/tool.rs
++++ b/src/bootstrap/tool.rs
+@@ -418,25 +418,25 @@ impl Step for Rustdoc {
+ 
+     fn run(self, builder: &Builder<'_>) -> PathBuf {
+         let target_compiler = builder.compiler(builder.top_stage, self.host);
+-        if target_compiler.stage == 0 {
+-            if !target_compiler.is_snapshot(builder) {
+-                panic!("rustdoc in stage 0 must be snapshot rustdoc");
+-            }
+-            return builder.initial_rustc.with_file_name(exe("rustdoc", &target_compiler.host));
+-        }
+         let target = target_compiler.host;
+-        // Similar to `compile::Assemble`, build with the previous stage's compiler. Otherwise
+-        // we'd have stageN/bin/rustc and stageN/bin/rustdoc be effectively different stage
+-        // compilers, which isn't what we want. Rustdoc should be linked in the same way as the
+-        // rustc compiler it's paired with, so it must be built with the previous stage compiler.
+-        let build_compiler = builder.compiler(target_compiler.stage - 1, builder.config.build);
+-
+-        // The presence of `target_compiler` ensures that the necessary libraries (codegen backends,
+-        // compiler libraries, ...) are built. Rustdoc does not require the presence of any
+-        // libraries within sysroot_libdir (i.e., rustlib), though doctests may want it (since
+-        // they'll be linked to those libraries). As such, don't explicitly `ensure` any additional
+-        // libraries here. The intuition here is that If we've built a compiler, we should be able
+-        // to build rustdoc.
++        let build_compiler = if target_compiler.stage == 0 {
++            builder.compiler(0, builder.config.build)
++        } else if target_compiler.stage >= 2 {
++            // Past stage 2, we consider the compiler to be ABI-compatible and hence capable of
++            // building rustdoc itself.
++            builder.compiler(target_compiler.stage, builder.config.build)
++        } else {
++            // Similar to `compile::Assemble`, build with the previous stage's compiler. Otherwise
++            // we'd have stageN/bin/rustc and stageN/bin/rustdoc be effectively different stage
++            // compilers, which isn't what we want.
++            builder.compiler(target_compiler.stage - 1, builder.config.build)
++        };
++
++        builder.ensure(compile::Rustc { compiler: build_compiler, target });
++        builder.ensure(compile::Rustc {
++            compiler: build_compiler,
++            target: builder.config.build,
++        });
+ 
+         let mut cargo = prepare_tool_cargo(
+             builder,

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -59,8 +59,7 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 S="${WORKDIR}/${MY_P}-src"
 
 PATCHES="${FILESDIR}/${P}-fix-codegen-path.patch
-${FILESDIR}/${P}-fix-clippy-sysroot.patch
-"
+${FILESDIR}/${P}-fix-rustdoc.patch"
 
 toml_usex() {
 	usex "$1" true false


### PR DESCRIPTION
Reverts https://github.com/rust-lang/rust/issues/58587 to build rustdoc.
Fix codegen search and clippy.