### PR TITLE
dev-lang/rust: unset SUDO_USER to disable vendoring

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -101,6 +101,8 @@ pkg_pretend() {
 }
 
 pkg_setup() {
+	unset SUDO_USER
+
 	pre_build_checks
 	python-any-r1_pkg_setup
 	if use system-llvm; then


### PR DESCRIPTION
Fixes #375. Rust's `bootstrap.py` [vendors dependencies when `SUDO_USER` is set](https://github.com/rust-lang/rust/blob/f693d339f175b3aa23a91c62632c5f0c86886059/src/bootstrap/bootstrap.py#L779-L786), which flat out doesn't work in the ebuild's environment (especially with `FEATURES="network-sandbox"` enabled), so if emerge is invoked with `sudo`, the build breaks.

Fortunately this bug only impacted `dev-lang/rust-9999`.

 This is much more elegant than using `package.env` or [a patch](https://github.com/gentoo/gentoo-rust/issues/375#issuecomment-504210488), and it really ought to work by default anyway.