### PR TITLE
dev-lang/rust: set debuginfo-level instead of boolean in config.toml

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -56,7 +56,7 @@ COMMON_DEPEND="
 	net-libs/http-parser:=
 	net-misc/curl[ssl]
 	app-eselect/eselect-rust
-	system-llvm? ( 
+	system-llvm? (
 		${LLVM_DEPEND}
 	)
 "
@@ -177,7 +177,7 @@ src_configure() {
 		mandir = "share/${P}/man"
 		[rust]
 		optimize = $(toml_usex !debug)
-		debuginfo = $(toml_usex debug)
+		debuginfo-level = $(usex debug 2 0)
 		debug-assertions = $(toml_usex debug)
 		default-linker = "$(tc-getCC)"
 		rpath = false


### PR DESCRIPTION
Fixes #402. `debuginfo = false` hasn't been valid since Rust commit [`28405ca`](https://github.com/rust-lang/rust/commit/28405cabd50181afa6eccfd7f2ee8eb363d35594); it's no longer a boolean. For rust-9999 to build, it should be replaced with `debuginfo-level = 0` or `debuginfo-level = 2` depending on the setting of the `debug` USE flag.