### PR TITLE
Accept letter releases of dev-libs/openssl-1.1.1

### DIFF
--- a/dev-lang/rust/rust-1.37.0-r666.ebuild
+++ b/dev-lang/rust/rust-1.37.0-r666.ebuild
@@ -47,7 +47,7 @@ IUSE="clippy debug doc libressl rls rustfmt thumbv7neon wasm ${ALL_LLVM_TARGETS[
 
 RDEPEND=">=app-eselect/eselect-rust-20190311
 		sys-libs/zlib
-		!libressl? ( <=dev-libs/openssl-1.1.1:= >=dev-libs/openssl-1.0.1:= )
+		!libressl? ( <dev-libs/openssl-1.1.2:= >=dev-libs/openssl-1.0.1:= )
 		libressl? ( <=dev-libs/libressl-2.9.0:= >=dev-libs/libressl-2.5:= )
 		net-libs/libssh2
 		net-libs/http-parser


### PR DESCRIPTION
Since this package is compartible with openssl-1.1.1, it should accept any letter release (currently openssl-1.1.1b-r2 and openssl-1.1.1c are in the tree) as the correct dependency.