### PR TITLE
Fix rust-bin-9999 ebuild: Do not fetch bogus url

### DIFF
--- a/dev-lang/rust-bin/rust-bin-9999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-9999.ebuild
@@ -55,12 +55,14 @@ src_unpack() {
 	mv "${WORKDIR}/rust-nightly-${postfix}" "${S}" || die
 
 	for arch in ${ALL_RUSTLIB_TARGETS}; do
-		use ${arch} && target=${arch#"rustlib_targets_"}
-		elog "Adding ${target}..."
-		wget "${MY_STDLIB_SRC_URI}-${target}.tar.xz" || die
-		unpack ./"rust-std-nightly-${target}.tar.xz"
-		mv "${WORKDIR}/rust-std-nightly-${target}/rust-std-${target}" "${S}/" || die
-		cat "${WORKDIR}/rust-std-nightly-${target}/components" >> "${S}/components"
+		if use ${arch}; then
+			target=${arch#"rustlib_targets_"}
+			elog "Adding ${target}..."
+			wget "${MY_STDLIB_SRC_URI}-${target}.tar.xz" || die
+			unpack ./"rust-std-nightly-${target}.tar.xz"
+			mv "${WORKDIR}/rust-std-nightly-${target}/rust-std-${target}" "${S}/" || die
+			cat "${WORKDIR}/rust-std-nightly-${target}/components" >> "${S}/components"
+		fi
 	done
 }
 


### PR DESCRIPTION
This is @temporary-username-largedicks's patch from #421 