### PR TITLE
dev-lang/rust-9999: raise llvm slot to 9 

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -47,7 +47,7 @@ LLVM_DEPEND="
 	)
 	<sys-devel/llvm-9:=
 "
-LLVM_MAX_SLOT=8
+LLVM_MAX_SLOT=9
 
 COMMON_DEPEND="
 	sys-libs/zlib

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -42,10 +42,10 @@ IUSE="clippy cpu_flags_x86_sse2 debug doc libressl rls rustfmt system-llvm wasm 
 # 3. Specify LLVM_MAX_SLOT, e.g. 8.
 LLVM_DEPEND="
 	|| (
-		sys-devel/llvm:8[llvm_targets_WebAssembly?]
-		wasm? ( =sys-devel/lld-8* )
+		sys-devel/llvm:9[llvm_targets_WebAssembly?]
+		wasm? ( =sys-devel/lld-9* )
 	)
-	<sys-devel/llvm-9:=
+	<sys-devel/llvm-10:=
 "
 LLVM_MAX_SLOT=9
 


### PR DESCRIPTION
@o01eg @cnd asking for a review: 

should we follow upstreams choice of llvm-9? 

Also: does my code do that? I'm not absolutly sure :-) 