### PR TITLE
cranelift-tools: wabt-sys demands cmake and gcc

### DIFF
--- a/dev-rust/cranelift-tools/cranelift-tools-0.45.0.ebuild
+++ b/dev-rust/cranelift-tools/cranelift-tools-0.45.0.ebuild
@@ -167,7 +167,10 @@ SLOT="0"
 KEYWORDS="~amd64"
 IUSE="cpu_flags_x86_sse2 test"
 
-DEPEND=">=virtual/rust-1.37.0"
+DEPEND=">=virtual/rust-1.37.0
+	dev-util/cmake
+	sys-devel/gcc"
+
 RDEPEND=""
 REQUIRED_USE="x86? ( cpu_flags_x86_sse2 )"
 


### PR DESCRIPTION
this will only show on cmake and gcc free systems