### PR TITLE
dev-lang/rust: allow llvm 8 or 9 for the live ebuild with system-llvm

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -42,6 +42,10 @@ IUSE="clippy cpu_flags_x86_sse2 debug doc libressl rls rustfmt system-llvm wasm 
 # 3. Specify LLVM_MAX_SLOT, e.g. 8.
 LLVM_DEPEND="
 	|| (
+		sys-devel/llvm:9[llvm_targets_WebAssembly?]
+		wasm? ( >=sys-devel/lld-9 )
+	)
+	(
 		sys-devel/llvm:8[llvm_targets_WebAssembly?]
 		wasm? ( >=sys-devel/lld-8 )
 	)


### PR DESCRIPTION
this is more closer to the instructions given in the comments of the ebuild. 