### PR TITLE
dev-lang/rust: the bootstrap script is executed via python, not via /usr/bin/xz

### DIFF
--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -74,7 +74,6 @@ DEPEND="${COMMON_DEPEND}
 		>=sys-devel/clang-3.5
 	)
 	dev-util/cmake
-	app-arch/xz-utils
 "
 
 RDEPEND="${COMMON_DEPEND}

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -72,7 +72,6 @@ DEPEND="${COMMON_DEPEND}
 		>=sys-devel/clang-3.5
 	)
 	dev-util/cmake
-	app-arch/xz-utils
 "
 
 RDEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
the xz-utils dependency is not needed, as the whole bootstrap script is done via the python-lzma module