### PR TITLE
dev-lang/rust: add thumbv7neon-unknown-linux-musleabihf target

### DIFF
--- a/dev-lang/rust/files/pr66103.patch
+++ b/dev-lang/rust/files/pr66103.patch
@@ -1,0 +1,69 @@
+From d01ebbb34b3f64099174c404b46f1f660bebbb6f Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Mon, 4 Nov 2019 21:48:22 -0600
+Subject: [PATCH] Add target thumbv7neon-unknown-linux-musleabihf
+
+This is a copy of thumbv7neon-unknown-linux-gnueabihf with musl changes
+merged from armv7-unknown-linux-musleabihf.
+---
+ src/librustc_target/spec/mod.rs               |  1 +
+ .../thumbv7neon_unknown_linux_musleabihf.rs   | 37 +++++++++++++++++++
+ 2 files changed, 38 insertions(+)
+ create mode 100644 src/librustc_target/spec/thumbv7neon_unknown_linux_musleabihf.rs
+
+diff --git a/src/librustc_target/spec/mod.rs b/src/librustc_target/spec/mod.rs
+index 6033d52c4411..baab7b4ca8eb 100644
+--- a/src/librustc_target/spec/mod.rs
++++ b/src/librustc_target/spec/mod.rs
+@@ -362,6 +362,7 @@ supported_targets! {
+     ("armv7-unknown-linux-gnueabi", armv7_unknown_linux_gnueabi),
+     ("armv7-unknown-linux-gnueabihf", armv7_unknown_linux_gnueabihf),
+     ("thumbv7neon-unknown-linux-gnueabihf", thumbv7neon_unknown_linux_gnueabihf),
++    ("thumbv7neon-unknown-linux-musleabihf", thumbv7neon_unknown_linux_musleabihf),
+     ("armv7-unknown-linux-musleabi", armv7_unknown_linux_musleabi),
+     ("armv7-unknown-linux-musleabihf", armv7_unknown_linux_musleabihf),
+     ("aarch64-unknown-linux-gnu", aarch64_unknown_linux_gnu),
+diff --git a/src/librustc_target/spec/thumbv7neon_unknown_linux_musleabihf.rs b/src/librustc_target/spec/thumbv7neon_unknown_linux_musleabihf.rs
+new file mode 100644
+index 000000000000..1270f391731b
+--- /dev/null
++++ b/src/librustc_target/spec/thumbv7neon_unknown_linux_musleabihf.rs
+@@ -0,0 +1,37 @@
++use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
++
++// This target is for musl Linux on ARMv7 with thumb mode enabled
++// (for consistency with Android and Debian-based distributions)
++// and with NEON unconditionally enabled and, therefore, with 32 FPU
++// registers enabled as well. See section A2.6.2 on page A2-56 in
++// https://static.docs.arm.com/ddi0406/cd/DDI0406C_d_armv7ar_arm.pdf
++
++pub fn target() -> TargetResult {
++    let base = super::linux_musl_base::opts();
++    Ok(Target {
++        // It's important we use "gnueabihf" and not "musleabihf" here. LLVM
++        // uses it to determine the calling convention and float ABI, and LLVM
++        // doesn't support the "musleabihf" value.
++        llvm_target: "armv7-unknown-linux-gnueabihf".to_string(),
++        target_endian: "little".to_string(),
++        target_pointer_width: "32".to_string(),
++        target_c_int_width: "32".to_string(),
++        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
++        arch: "arm".to_string(),
++        target_os: "linux".to_string(),
++        target_env: "musl".to_string(),
++        target_vendor: "unknown".to_string(),
++        linker_flavor: LinkerFlavor::Gcc,
++
++        // Most of these settings are copied from the thumbv7neon_unknown_linux_gnueabihf
++        // target.
++        options: TargetOptions {
++            features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".to_string(),
++            cpu: "generic".to_string(),
++            max_atomic_width: Some(64),
++            abi_blacklist: super::arm_base::abi_blacklist(),
++            target_mcount: "\u{1}mcount".to_string(),
++            .. base
++        }
++    })
++}
+

--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -93,6 +93,9 @@ PATCHES=(
 
 	# upstream issue: https://github.com/rust-lang/rust/issues/65757
 	"${FILESDIR}"/pr65932.patch
+
+	# this adds a thumbv7neon-musl target for neon support on musl with armv7
+	"${FILESDIR}"/pr66103.patch
 	)
 
 S="${WORKDIR}/${MY_P}-src"

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -89,6 +89,9 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 PATCHES=(
 	# upstream issue: https://github.com/rust-lang/rust/issues/65757
 	"${FILESDIR}"/pr65932.patch
+
+	# this adds a thumbv7neon-musl target for neon support on musl with armv7
+	"${FILESDIR}"/pr66103.patch
 	)
 
 S="${WORKDIR}/${MY_P}-src"


### PR DESCRIPTION
there's an additional rust-std for armv7 when there's neon and thumbv2
optimizations available. glibc based toolchain has it for a longer time
now, and firefox does claim it when configured with --enbable-neon

It's needed on top of the actuall armv7*-unknown-linux-musleabihf std lib,
so it is not a replacement.

