### PR TITLE
dev-lang/rust: pr65474 must be dropped from the beta ebuild

### DIFF
--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -89,8 +89,6 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 "
 
 PATCHES=( 
-	"${FILESDIR}"/pr65474.patch
-
 	# upstream issue: https://github.com/rust-lang/rust/issues/65757
 	"${FILESDIR}"/pr65932.patch
 


### PR DESCRIPTION
as the beta branch got updated to v1.40.0, into which the patch got
merged by upstream.

Keeping the patch online for possible use in rust-1.39.0 ebuild

