### PR TITLE
dev-lang/rust: add rust-1.39.0-r667 with pr65474

### DIFF
--- a/dev-lang/rust/rust-1.39.0-r667.ebuild
+++ b/dev-lang/rust/rust-1.39.0-r667.ebuild
@@ -1,0 +1,296 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy )
+
+inherit multiprocessing multilib-build python-any-r1 toolchain-funcs versionator
+
+ABI_VER="$(get_version_component_range 1-2)"
+SLOT="dev/${ABI_VER}"
+MY_P="rustc-${PV}"
+SRC="${MY_P}-src.tar.xz"
+#KEYWORDS="~amd64 ~arm64 ~x86"
+
+CHOST_amd64=x86_64-unknown-linux-gnu
+CHOST_x86=i686-unknown-linux-gnu
+CHOST_arm64=aarch64-unknown-linux-gnu
+CHOST_arm=armv7-unknown-linux-gnueabihf
+
+RUST_STAGE0_VERSION="1.$(($(get_version_component_range 2) - 1)).0"
+RUST_STAGE0_amd64="rust-${RUST_STAGE0_VERSION}-${CHOST_amd64}"
+RUST_STAGE0_x86="rust-${RUST_STAGE0_VERSION}-${CHOST_x86}"
+RUST_STAGE0_arm64="rust-${RUST_STAGE0_VERSION}-${CHOST_arm64}"
+RUST_STAGE0_armv7="rust-${RUST_STAGE0_VERSION}-${CHOST_arm}"
+
+CARGO_DEPEND_VERSION="0.$(($(get_version_component_range 2))).0"
+
+DESCRIPTION="Systems programming language from Mozilla"
+HOMEPAGE="https://www.rust-lang.org/"
+
+SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.xz
+	amd64? ( https://static.rust-lang.org/dist/${RUST_STAGE0_amd64}.tar.xz )
+	x86? ( https://static.rust-lang.org/dist/${RUST_STAGE0_x86}.tar.xz )
+	arm64? ( https://static.rust-lang.org/dist/${RUST_STAGE0_arm64}.tar.xz )
+	arm? ( https://static.rust-lang.org/dist/${RUST_STAGE0_armv7}.tar.xz )
+"
+
+ALL_LLVM_TARGETS=( AArch64 AMDGPU ARM BPF Hexagon Lanai Mips MSP430
+	NVPTX PowerPC Sparc SystemZ X86 XCore )
+ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
+LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/?}
+
+LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
+
+IUSE="clippy debug doc libressl rls rustfmt thumbv7neon wasm ${ALL_LLVM_TARGETS[*]}"
+
+RDEPEND=">=app-eselect/eselect-rust-20190311
+		sys-libs/zlib
+		!libressl? ( <dev-libs/openssl-1.1.2:= >=dev-libs/openssl-1.0.1:= )
+		libressl? ( <=dev-libs/libressl-2.9.0:= >=dev-libs/libressl-2.5:= )
+		net-libs/libssh2
+		net-libs/http-parser
+		net-misc/curl[ssl]
+		"
+DEPEND="${RDEPEND}
+	${PYTHON_DEPS}
+	|| (
+		>=sys-devel/gcc-4.7
+		>=sys-devel/clang-3.5
+	)
+	!dev-util/cargo
+	rustfmt? ( !dev-util/rustfmt )
+	dev-util/cmake
+"
+PDEPEND=""
+
+REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )"
+
+PATCHES=( 
+	# https://github.com/rust-lang/rust/pull/65474
+	"${FILESDIR}"/pr65474.patch
+	"${FILESDIR}"/pr66103.patch
+	)
+
+
+S="${WORKDIR}/${MY_P}-src"
+
+toml_usex() {
+	usex "$1" true false
+}
+
+src_prepare() {
+	local rust_stage0_root="${WORKDIR}"/rust-stage0
+
+	local rust_stage0_name="RUST_STAGE0_${ARCH}"
+	local rust_stage0="${!rust_stage0_name}"
+
+	"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig --destdir="${rust_stage0_root}" --prefix=/ || die
+
+	default
+}
+
+src_configure() {
+	local rust_target="" rust_targets="" rust_target_name arch_cflags
+
+	# Collect rust target names to compile standard libs for all ABIs.
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_target_name="CHOST_${v##*.}"
+		rust_targets="${rust_targets},\"${!rust_target_name}\""
+	done
+	if use wasm; then
+		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
+	fi
+	if use arm && use thumbv7neon; then
+		rust_targets="${rust_targets},\"thumbv7neon-unknown-linux-gnueabihf\""
+	fi
+
+	rust_targets="${rust_targets#,}"
+
+	local extended="true" tools="\"cargo\","
+	if use clippy; then
+		tools="\"clippy\",$tools"
+	fi
+	if use rls; then
+		tools="\"rls\",\"analysis\",\"src\",$tools"
+	fi
+	if use rustfmt; then
+		tools="\"rustfmt\",$tools"
+	fi
+
+	local rust_stage0_root="${WORKDIR}"/rust-stage0
+
+	rust_target_name="CHOST_${ARCH}"
+	rust_target="${!rust_target_name}"
+
+	cat <<- EOF > "${S}"/config.toml
+		[llvm]
+		optimize = $(toml_usex !debug)
+		release-debuginfo = $(toml_usex debug)
+		assertions = $(toml_usex debug)
+		targets = "${LLVM_TARGETS// /;}"
+		experimental-targets = ""
+		[build]
+		build = "${rust_target}"
+		host = ["${rust_target}"]
+		target = [${rust_targets}]
+		cargo = "${rust_stage0_root}/bin/cargo"
+		rustc = "${rust_stage0_root}/bin/rustc"
+		docs = $(toml_usex doc)
+		submodules = false
+		python = "${EPYTHON}"
+		locked-deps = true
+		vendor = true
+		extended = ${extended}
+		tools = [${tools}]
+		verbose = 2
+		[install]
+		prefix = "${EPREFIX}/usr"
+		libdir = "$(get_libdir)"
+		docdir = "share/doc/${P}"
+		mandir = "share/${P}/man"
+		[rust]
+		optimize = $(toml_usex !debug)
+		debug = $(toml_usex debug)
+		debug-assertions = $(toml_usex debug)
+		default-linker = "$(tc-getCC)"
+		rpath = false
+		lld = $(toml_usex wasm)
+	EOF
+
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_target=$(get_abi_CHOST ${v##*.})
+		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+
+		cat <<- EOF >> "${S}"/config.env
+			CFLAGS_${rust_target}=${arch_cflags}
+		EOF
+
+		cat <<- EOF >> "${S}"/config.toml
+			[target.${rust_target}]
+			cc = "$(tc-getBUILD_CC)"
+			cxx = "$(tc-getBUILD_CXX)"
+			linker = "$(tc-getCC)"
+			ar = "$(tc-getAR)"
+		EOF
+	done
+
+	if use wasm; then
+		cat <<- EOF >> "${S}"/config.toml
+			[target.wasm32-unknown-unknown]
+			linker = "lld"
+		EOF
+	fi
+
+	if use arm && use thumbv7neon; then
+		cat <<- EOF >> "${S}"/config.toml
+			[target.thumbv7neon-unknown-linux-gnueabihf]
+			cc = "$(tc-getBUILD_CC)"
+			cxx = "$(tc-getBUILD_CXX)"
+			linker = "$(tc-getCC)"
+			ar = "$(tc-getAR)"
+		EOF
+	fi
+}
+
+src_compile() {
+	env $(cat "${S}"/config.env)\
+		./x.py build --config="${S}"/config.toml -j$(makeopts_jobs) \
+		--exclude src/tools/miri || die # https://github.com/rust-lang/rust/issues/52305
+}
+
+src_install() {
+	local rust_target abi_libdir
+
+	env DESTDIR="${D}" ./x.py install || die
+
+	mv "${D}/usr/bin/rustc" "${D}/usr/bin/rustc-${PV}" || die
+	mv "${D}/usr/bin/rustdoc" "${D}/usr/bin/rustdoc-${PV}" || die
+	mv "${D}/usr/bin/rust-gdb" "${D}/usr/bin/rust-gdb-${PV}" || die
+	mv "${D}/usr/bin/rust-lldb" "${D}/usr/bin/rust-lldb-${PV}" || die
+	mv "${D}/usr/bin/cargo" "${D}/usr/bin/cargo-${PV}" || die
+	if use clippy; then
+		mv "${D}/usr/bin/clippy-driver" "${D}/usr/bin/clippy-driver-${PV}" || die
+		mv "${D}/usr/bin/cargo-clippy" "${D}/usr/bin/cargo-clippy-${PV}" || die
+	fi
+	if use rls; then
+		mv "${D}/usr/bin/rls" "${D}/usr/bin/rls-${PV}" || die
+	fi
+	if use rustfmt; then
+		mv "${D}/usr/bin/rustfmt" "${D}/usr/bin/rustfmt-${PV}" || die
+		mv "${D}/usr/bin/cargo-fmt" "${D}/usr/bin/cargo-fmt-${PV}" || die
+	fi
+
+	# Copy shared library versions of standard libraries for all targets
+	# into the system's abi-dependent lib directories because the rust
+	# installer only does so for the native ABI.
+	for v in $(multilib_get_enabled_abi_pairs); do
+		if [ ${v##*.} = ${DEFAULT_ABI} ]; then
+			continue
+		fi
+		abi_libdir=$(get_abi_LIBDIR ${v##*.})
+		rust_target=$(get_abi_CHOST ${v##*.})
+		mkdir -p "${D}/usr/${abi_libdir}"
+		cp "${D}/usr/$(get_libdir)/rustlib/${rust_target}/lib"/*.so \
+		   "${D}/usr/${abi_libdir}" || die
+	done
+
+	dodoc COPYRIGHT
+
+	# FIXME:
+	# Really not sure if that env is needed, specailly LDPATH
+	cat <<-EOF > "${T}"/50${P}
+		LDPATH="/usr/$(get_libdir)/${P}"
+		MANPATH="/usr/share/${P}/man"
+	EOF
+	doenvd "${T}"/50${P}
+
+	cat <<-EOF > "${T}/provider-${P}"
+		/usr/bin/rustdoc
+		/usr/bin/rust-gdb
+		/usr/bin/rust-lldb
+	EOF
+	echo /usr/bin/cargo >> "${T}/provider-${P}"
+	if use clippy; then
+		echo /usr/bin/clippy-driver >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-clippy >> "${T}/provider-${P}"
+	fi
+	if use rls; then
+		echo /usr/bin/rls >> "${T}/provider-${P}"
+	fi
+	if use rustfmt; then
+		echo /usr/bin/rustfmt >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-fmt >> "${T}/provider-${P}"
+	fi
+	dodir /etc/env.d/rust
+	insinto /etc/env.d/rust
+	doins "${T}/provider-${P}"
+}
+
+pkg_postinst() {
+	eselect rust update --if-unset
+
+	elog "Rust installs a helper script for calling GDB and LLDB,"
+	elog "for your convenience it is installed under /usr/bin/rust-{gdb,lldb}-${PV}."
+
+	ewarn "cargo is now installed from dev-lang/rust{,-bin} instead of dev-util/cargo."
+	ewarn "This might have resulted in a dangling symlink for /usr/bin/cargo on some"
+	ewarn "systems. This can be resolved by calling 'sudo eselect rust set ${P}'."
+
+	if has_version app-editors/emacs || has_version app-editors/emacs-vcs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-vim to get vim support for rust."
+	fi
+
+	if has_version 'app-shells/zsh'; then
+		elog "install app-shells/rust-zshcomp to get zsh completion for rust."
+	fi
+}
+
+pkg_postrm() {
+	eselect rust unset --if-invalid
+}


### PR DESCRIPTION
pr65474 minimizes the amount of files needed for the install
of a rust-std component by not merging certain dev-header
files and other instable components.

more information:
https://github.com/rust-lang/rust/pull/64823
https://github.com/rust-lang/rust/pull/65474

I opted for +-r1 and dropped keywords, for testing.

Also included pr66103, it shouldn't hurt anyone. 