### PR TITLE
dev-lang/rust-9999: cleanup upstreamed patches

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -86,13 +86,7 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	?? ( system-llvm sanitize )
 "
 
-PATCHES=(
-	# upstream issue: https://github.com/rust-lang/rust/issues/65757
-	"${FILESDIR}"/pr65932.patch
-
-	# this adds a thumbv7neon-musl target for neon support on musl with armv7
-	"${FILESDIR}"/pr66103.patch
-	)
+#PATCHES=( )
 
 S="${WORKDIR}/${MY_P}-src"
 


### PR DESCRIPTION
pr65932 was merged as part of a bigger rollup in pr66366
the patch must stay in the overlay for the beta live ebuild, either
as long as it takes to uplift it to the beta, or up to the next release.

pr66103 also got merged a few days ago into master. 

Closes: https://github.com/gentoo/gentoo-rust/issues/454