### PR TITLE
dev-lang/rust-999: remove stale patches

### DIFF
--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -88,13 +88,7 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	?? ( system-llvm sanitize )
 "
 
-PATCHES=( 
-	# upstream issue: https://github.com/rust-lang/rust/issues/65757
-	"${FILESDIR}"/pr65932.patch
-
-	# this adds a thumbv7neon-musl target for neon support on musl with armv7
-	"${FILESDIR}"/pr66103.patch
-	)
+#PATCHES=( )
 
 S="${WORKDIR}/${MY_P}-src"
 


### PR DESCRIPTION
all of the removed patches have been merged upstream. 