### PR TITLE
cargo.eclass: add args to cargo_src_install()

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -153,7 +153,7 @@ cargo_src_compile() {
 cargo_src_install() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	cargo install -j $(makeopts_jobs) --root="${D}/usr" $(usex debug --debug "") \
+	cargo install -j $(makeopts_jobs) --root="${D}/usr" $(usex debug --debug "") "$@" \
 		|| die "cargo install failed"
 	rm -f "${D}/usr/.crates.toml"
 


### PR DESCRIPTION
media-sound/spotifyd and media-sound/spotify-tui were tested with
the cargo eclass in the main package repo, they currently fail
to install as they try to pass arguments into cargo_src_install()