### PR TITLE
cargo eclass: backport patch to use regex for name/version extraction

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -39,11 +39,11 @@ cargo_crate_uris() {
 	readonly regex='^(.*)-([0-9]+\.[0-9]+\.[0-9]+.*)$'
 	local crate
 	for crate in "$@"; do
-		if [[ "${CARGO_FETCH_CRATES}" == "not" ]]; then
 		local name version url
 		[[ $crate =~ $regex ]] || die "Could not parse name and version from crate: $crate"
 		name="${BASH_REMATCH[1]}"
 		version="${BASH_REMATCH[2]}"
+		if [[ "${CARGO_FETCH_CRATES}" == "not" ]]; then
 			url="https://crates.io/api/v1/crates/${name}/${version}/download -> ${crate}.crate"
 		else
 			url=""

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -36,17 +36,14 @@ ECARGO_VENDOR="${ECARGO_HOME}/gentoo"
 # @DESCRIPTION:
 # Generates the URIs to put in SRC_URI to help fetch dependencies.
 cargo_crate_uris() {
+	readonly regex='^(.*)-([0-9]+\.[0-9]+\.[0-9]+.*)$'
 	local crate
 	for crate in "$@"; do
-		local name version url pretag
-		name="${crate%-*}"
-		version="${crate##*-}"
-		pretag="[a-zA-Z]+"
-		if [[ $version =~ $pretag ]]; then
-			version="${name##*-}-${version}"
-			name="${name%-*}"
-		fi
 		if [[ "${CARGO_FETCH_CRATES}" == "not" ]]; then
+		local name version url
+		[[ $crate =~ $regex ]] || die "Could not parse name and version from crate: $crate"
+		name="${BASH_REMATCH[1]}"
+		version="${BASH_REMATCH[2]}"
 			url="https://crates.io/api/v1/crates/${name}/${version}/download -> ${crate}.crate"
 		else
 			url=""


### PR DESCRIPTION
taken from https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=2835a612827749228ca89fbd982df2bb4f072742

original bug: https://bugs.gentoo.org/705044
