### PR TITLE
dev-lang/rust-bin: keywords mask -999 & -9999 ebuilds

### DIFF
--- a/dev-lang/rust-bin/rust-bin-999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,12 +17,13 @@ ALL_RUSTLIB_TARGETS=( "${ALL_RUSTLIB_TARGETS[@]/#/rustlib_targets_}" )
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="beta"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS=""
 RESTRICT="network-sandbox"
 
 IUSE="clippy cpu_flags_x86_sse2 doc libressl rls rustfmt ${ALL_RUSTLIB_TARGETS[*]}"
 
-CDEPEND=">=app-eselect/eselect-rust-0.3_pre20150425
+CDEPEND="
+	>=app-eselect/eselect-rust-0.3_pre20150425
 	!dev-lang/rust:0
 	rustfmt? ( !dev-util/rustfmt )
 "

--- a/dev-lang/rust-bin/rust-bin-9999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,12 +22,13 @@ ALL_RUSTLIB_TARGETS=( "${ALL_RUSTLIB_TARGETS[@]/#/rustlib_targets_}" )
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="nightly"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS=""
 RESTRICT="network-sandbox"
 
 IUSE="clippy cpu_flags_x86_sse2 doc libressl rls rustfmt ${ALL_RUSTLIB_TARGETS[*]}"
 
-CDEPEND=">=app-eselect/eselect-rust-0.3_pre20150425
+CDEPEND="
+	>=app-eselect/eselect-rust-0.3_pre20150425
 	!dev-lang/rust:0
 	rustfmt? ( !dev-util/rustfmt )
 "


### PR DESCRIPTION
-999* should be keyword unmasked only when they're needed.