### PR TITLE
Fix install of media-sound/spotifyd and media-sound/spotify-tui

### DIFF
--- a/media-sound/spotify-tui/spotify-tui-0.10.0.ebuild
+++ b/media-sound/spotify-tui/spotify-tui-0.10.0.ebuild
@@ -238,7 +238,3 @@ RDEPEND="
 libressl? ( dev-libs/libressl:0= )
 "
 DEPEND="${DEPEND} virtual/pkgconfig"
-
-src_install() {
-	cargo_src_install --path=.
-}

--- a/media-sound/spotifyd/spotifyd-0.2.20.ebuild
+++ b/media-sound/spotifyd/spotifyd-0.2.20.ebuild
@@ -403,7 +403,7 @@ src_compile() {
 }
 
 src_install() {
-	cargo_src_install --path=. ${myfeatures:+--features "${myfeatures[*]}"} --no-default-features
+	cargo_src_install ${myfeatures:+--features "${myfeatures[*]}"} --no-default-features
 
 	keepdir /etc/xdg/spotifyd
 }


### PR DESCRIPTION
`--path` is set in `cargo.eclass` since #419 

Fixes #499